### PR TITLE
Alteração na configuração de cache do Gradle no CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,16 +27,16 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           keys:
-          - v1-dependencies-{{ .Branch }}-{{ checksum "build.gradle" }}
-          - v1-dependencies-{{ checksum "build.gradle" }}
-          - v1-dependencies-
+          - v2-dependencies-{{ .Branch }}-{{ checksum "build.gradle" }}
+          - v2-dependencies-{{ checksum "build.gradle" }}
+          - v2-dependencies-
 
       - run: gradle dependencies
 
       - save_cache:
           paths:
             - ~/.gradle
-          key: v1-dependencies-{{ .Branch }}-{{ checksum "build.gradle" }}
+          key: v2-dependencies-{{ .Branch }}-{{ checksum "build.gradle" }}
         
       # run tests!
       - run: gradle test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,8 +27,8 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           keys:
+          - v1-dependencies-{{ .Branch }}-{{ checksum "build.gradle" }}
           - v1-dependencies-{{ checksum "build.gradle" }}
-          # fallback to using the latest cache if no exact match is found
           - v1-dependencies-
 
       - run: gradle dependencies
@@ -36,7 +36,7 @@ jobs:
       - save_cache:
           paths:
             - ~/.gradle
-          key: v1-dependencies-{{ checksum "build.gradle" }}
+          key: v1-dependencies-{{ .Branch }}-{{ checksum "build.gradle" }}
         
       # run tests!
       - run: gradle test


### PR DESCRIPTION
# O que foi mudado

O arquivo `.circleci/config.yml` especifica as etapas de _build_ do projeto, usando o Gradle. Uma das etapas é o cache das dependências, que mantém as versões usadas em cada build para não buscá-las novamente cada vez. O cache é identificado por uma chave, que até agora, era composta por um _checksum_ do arquivo `build.gradle`.
Foi mudada a versão no início da chave do cache (para invalidar o antigo) e adicionado o nome da _branch,_ já que _branches_ diferentes podem ter dependências diferentes.

# Por que foi mudado

O build estava falhando pois não conseguia baixar as dependências, que estavam com versões antigas no cache. Não sei exatamente por que o _checksum_ do `build.gradle`, que estava na chave do cache, não foi o suficiente para invalidá-lo. Portanto, é possível que esse problema volte a acontecer.
