### PR TITLE
Arrumar padrões de atributos do pet

### DIFF
--- a/src/main/java/br/com/academiadev/suicidesquad/entity/Pet.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/entity/Pet.java
@@ -37,23 +37,27 @@ public class Pet implements Serializable {
 
     @JsonProperty("comprimento_pelo")
     @Convert(converter = ComprimentoPeloConverter.class)
+    @NotNull
     private ComprimentoPelo comprimentoPelo;
 
     @JsonProperty("sexo")
     @Convert(converter = SexoPetConverter.class)
-    private SexoPet sexo;
+    private SexoPet sexo = SexoPet.NAO_INFORMADO;
 
     @JsonProperty("categoria")
     @Convert(converter = CategoriaConverter.class)
+    @NotNull
     private Categoria categoria;
 
     @JsonProperty("vacinacao")
     @Convert(converter = VacinacaoConverter.class)
-    private Vacinacao vacinacao;
+    @NotNull
+    private Vacinacao vacinacao = Vacinacao.NAO_INFORMADO;
 
     @JsonProperty("castracao")
     @Convert(converter = CastracaoConverter.class)
-    private Castracao castracao;
+    @NotNull
+    private Castracao castracao = Castracao.NAO_INFORMADO;
 
     @ManyToOne
     @JoinColumn(name = "id_localizacao")

--- a/src/main/java/br/com/academiadev/suicidesquad/enums/SexoPet.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/enums/SexoPet.java
@@ -2,7 +2,8 @@ package br.com.academiadev.suicidesquad.enums;
 
 public enum SexoPet {
     MACHO(1),
-    FEMEA(2);
+    FEMEA(2),
+    NAO_INFORMADO(3);
 
     private Integer id;
 

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -2,19 +2,21 @@ INSERT INTO localizacao (bairro, cidade, uf) VALUES
   ('Centro', 'São Francisco do Sul', 'SC'),
   ('Floresta', 'Joinville', 'SC');
 
-INSERT INTO pet (porte, tipo, categoria, comprimento_pelo, sexo, raca, id_localizacao) VALUES
-  (1, 1, 1, 1, 1, 1, 1),
-  (2, 2, 2, 4, 2, 2, null),
-  (3, 3, 3, 3, 1, 3, null);
+INSERT INTO pet (
+  comprimento_pelo, id_localizacao, porte, raca, tipo, sexo, categoria, vacinacao, castracao
+) VALUES
+  (1, 1, 1, 1, 1, 1, 1, 1, 1),
+  (2, 2, 2, 2, 2, 2, 2, 2, 2),
+  (3, 1, 3, 6, 3, 3, 3, 3, 3);
 
 INSERT INTO registro (id_pet, situacao, data) VALUES
   (1, 1, '2018-01-01T01:00:00'),
   (1, 2, '2018-02-01T02:00:00'),
   (1, 3, '2018-03-01T03:00:00'),
-  (2, 2, '2018-02-03T02:00:00'),
-  (3, 3, '2018-02-03T03:00:00');
+  (1, 2, '2018-02-03T02:00:00'),
+  (1, 3, '2018-02-03T03:00:00');
 
 INSERT INTO pet_cor (PET_ID, CORES) VALUES
   (1, 1),
   (1, 2),
-  (3, 3);
+  (1, 3);

--- a/src/test/java/br/com/academiadev/suicidesquad/controller/PetControllerTest.java
+++ b/src/test/java/br/com/academiadev/suicidesquad/controller/PetControllerTest.java
@@ -137,6 +137,7 @@ public class PetControllerTest {
         petJson.put("tipo", "CACHORRO");
         petJson.put("porte", "PEQUENO");
         petJson.put("raca", "CACHORRO_SRD");
+        petJson.put("comprimento_pelo", "CURTO");
 
         this.mvc
                 .perform(post("/pets")


### PR DESCRIPTION
# O que foi feito

Definidos valores padrões ao invés de nulos nos seguintes atributos do Pet:
- SexoPet
- Vacinacao
- Castracao

Adicionado valor NAO_INFORMADO no SexoPet para agir como padrão.

# Por que foi feito

Para manter a integridade do banco de dados.
