### PR TITLE
Adicionar auditing (data de criação e modificação) ao pet e ao usuário

### DIFF
--- a/src/main/java/br/com/academiadev/suicidesquad/config/AuditingConfig.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/config/AuditingConfig.java
@@ -1,0 +1,9 @@
+package br.com.academiadev.suicidesquad.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class AuditingConfig {
+}

--- a/src/main/java/br/com/academiadev/suicidesquad/entity/AuditableEntity.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/entity/AuditableEntity.java
@@ -1,0 +1,26 @@
+package br.com.academiadev.suicidesquad.entity;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@Data
+@EqualsAndHashCode(callSuper = true)
+@EntityListeners({AuditingEntityListener.class})
+public class AuditableEntity<PK> extends BaseEntity<PK> {
+    @CreatedDate
+    @JsonProperty("created_date")
+    private LocalDateTime createdDate;
+
+    @LastModifiedDate
+    @JsonProperty("last_modified_date")
+    private LocalDateTime lastModifiedDate;
+}

--- a/src/main/java/br/com/academiadev/suicidesquad/entity/AuditableEntity.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/entity/AuditableEntity.java
@@ -1,6 +1,7 @@
 package br.com.academiadev.suicidesquad.entity;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModelProperty;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import org.springframework.data.annotation.CreatedDate;
@@ -20,9 +21,11 @@ public class AuditableEntity<PK> extends BaseEntity<PK> {
     @CreatedDate
     @Column(updatable = false)
     @JsonProperty("created_date")
+    @ApiModelProperty(hidden = true)
     private LocalDateTime createdDate;
 
     @LastModifiedDate
     @JsonProperty("last_modified_date")
+    @ApiModelProperty(hidden = true)
     private LocalDateTime lastModifiedDate;
 }

--- a/src/main/java/br/com/academiadev/suicidesquad/entity/AuditableEntity.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/entity/AuditableEntity.java
@@ -7,6 +7,7 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+import javax.persistence.Column;
 import javax.persistence.EntityListeners;
 import javax.persistence.MappedSuperclass;
 import java.time.LocalDateTime;
@@ -17,6 +18,7 @@ import java.time.LocalDateTime;
 @EntityListeners({AuditingEntityListener.class})
 public class AuditableEntity<PK> extends BaseEntity<PK> {
     @CreatedDate
+    @Column(updatable = false)
     @JsonProperty("created_date")
     private LocalDateTime createdDate;
 

--- a/src/main/java/br/com/academiadev/suicidesquad/entity/Pet.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/entity/Pet.java
@@ -22,7 +22,7 @@ import java.util.Set;
 @Entity
 @Table(name = "pet")
 @JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
-public class Pet extends BaseEntity<Long> {
+public class Pet extends AuditableEntity<Long> {
     @JsonProperty("tipo")
     @Convert(converter = TipoConverter.class)
     @NotNull

--- a/src/main/java/br/com/academiadev/suicidesquad/entity/Usuario.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/entity/Usuario.java
@@ -25,7 +25,7 @@ import java.util.List;
 @Entity
 @Table(name = "usuario")
 @JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
-public class Usuario extends BaseEntity<Long> {
+public class Usuario extends AuditableEntity<Long> {
     @NotNull
     @Size(min = 1, max = 120)
     private String nome;


### PR DESCRIPTION
# O que foi feito

Criei uma classe `AuditableEntity` com os campos  `createdDate` e `modifiedDate`, com as _annotations_ apropriadas para guardas estas datas automaticamente. As _entities_ `Pet` e `Usuario` passam a herdar desta classe.

Criei uma classe de configuração `AuditingConfig` para habilitar esta funcionalidade do JPA.

# Por que foi feito

Para obter mais metadados sobre as ações feitas no banco de dados.
