### PR TITLE
Login com Facebook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@
 ### Other ###
 
 /bin/
+/src/main/resources/application-*.properties

--- a/build.gradle
+++ b/build.gradle
@@ -63,3 +63,8 @@ lombok {
 	version = "1.18.4"
 	sha256 = "39f3922deb679b1852af519eb227157ef2dd0a21eec3542c8ce1b45f2df39742"
 }
+
+// Herdar configurações do Gradle
+// Possibilita isso:
+// ./gradlew bootRun -Dspring.profiles.active=prod
+bootRun.systemProperties = System.properties

--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,8 @@ dependencies {
 
 	compile('io.springfox:springfox-swagger-ui:2.9.2')
 	compile('io.springfox:springfox-swagger2:2.9.2')
+	implementation('org.springframework.social:spring-social-core:1.1.6.RELEASE')
+	implementation('org.springframework.social:spring-social-facebook:2.0.3.RELEASE')
 
 	compile("com.h2database:h2")
 	runtimeOnly('org.postgresql:postgresql')

--- a/src/main/java/br/com/academiadev/suicidesquad/controller/FacebookAuthController.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/controller/FacebookAuthController.java
@@ -1,0 +1,85 @@
+package br.com.academiadev.suicidesquad.controller;
+
+import br.com.academiadev.suicidesquad.entity.Usuario;
+import br.com.academiadev.suicidesquad.enums.SexoUsuario;
+import br.com.academiadev.suicidesquad.service.FacebookService;
+import br.com.academiadev.suicidesquad.service.UsuarioService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.social.facebook.api.User;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Optional;
+
+@RestController
+@ConditionalOnProperty(prefix = "app.social.facebook", name = "enabled")
+@RequestMapping("/facebook")
+public class FacebookAuthController {
+
+    private final FacebookService facebookService;
+
+    private final UsuarioService usuarioService;
+
+    @Value("${app.social.facebook.frontend-redirect-uri:}")
+    private String frontendRedirectUri;
+
+    @Autowired
+    public FacebookAuthController(FacebookService facebookService, UsuarioService usuarioService) {
+        this.facebookService = facebookService;
+        this.usuarioService = usuarioService;
+    }
+
+    @GetMapping("/authorization")
+    public void getFacebookAuthorization(HttpServletResponse response) throws IOException {
+        response.sendRedirect(facebookService.createAuthorizationURL());
+    }
+
+    @GetMapping("/callback")
+    public void facebookCallback(HttpServletResponse response, @RequestParam("code") String code) throws IOException {
+        Optional<User> facebookUser = facebookService.getAccessToken(code).flatMap(facebookService::getUser);
+
+        if (facebookUser.isPresent()) {
+            Usuario usuario = buildUsuarioFromFacebookUser(facebookUser.get());
+            if (usuario.getEmail() == null) {
+                // TODO: Tratar quando o usuário não tem email
+            }
+            // TODO: Gerar token de sessão colocar em um cookie
+            final Cookie tokenCookie = new Cookie("token", "eu_sou_um_token");
+            tokenCookie.setHttpOnly(true);
+            response.addCookie(tokenCookie);
+            usuarioService.save(usuario);
+        }
+
+        response.sendRedirect(frontendRedirectUri);
+    }
+
+    private Usuario buildUsuarioFromFacebookUser(User facebookUser) {
+        return usuarioService.findByFacebookUserId(facebookUser.getId())
+                .orElseGet(() -> Usuario.builder()
+                        .nome(facebookUser.getName())
+                        .email(facebookUser.getEmail())
+                        .facebookUserId(facebookUser.getId())
+                        .sexo(determinarSexoUsuario(facebookUser.getGender()))
+                        .build());
+
+    }
+
+    private SexoUsuario determinarSexoUsuario(String facebookUserGender) {
+        if (facebookUserGender == null) {
+            return SexoUsuario.NAO_INFORMADO;
+        } else if (facebookUserGender.equals("masculino")) {
+            return SexoUsuario.MASCULINO;
+        } else if (facebookUserGender.equals("feminino")) {
+            return SexoUsuario.FEMININO;
+        } else {
+            return SexoUsuario.NAO_INFORMADO;
+        }
+    }
+}

--- a/src/main/java/br/com/academiadev/suicidesquad/entity/Usuario.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/entity/Usuario.java
@@ -2,6 +2,7 @@ package br.com.academiadev.suicidesquad.entity;
 
 import br.com.academiadev.suicidesquad.converter.SexoUsuarioConverter;
 import br.com.academiadev.suicidesquad.enums.SexoUsuario;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.*;
@@ -48,6 +49,9 @@ public class Usuario extends AuditableEntity<Long> implements UserDetails {
 
     @JsonProperty("data_nascimento")
     private LocalDate dataNascimento;
+
+    @JsonIgnore
+    private String facebookUserId;
 
     @ManyToOne(cascade = CascadeType.PERSIST)
     @JoinColumn(name = "id_localizacao")

--- a/src/main/java/br/com/academiadev/suicidesquad/entity/Usuario.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/entity/Usuario.java
@@ -39,7 +39,6 @@ public class Usuario extends AuditableEntity<Long> implements UserDetails {
     @Email
     private String email;
 
-    @NotNull
     private String senha;
 
     @NotNull
@@ -47,7 +46,6 @@ public class Usuario extends AuditableEntity<Long> implements UserDetails {
     @Builder.Default
     private SexoUsuario sexo = SexoUsuario.NAO_INFORMADO;
 
-    @NotNull
     @JsonProperty("data_nascimento")
     private LocalDate dataNascimento;
 

--- a/src/main/java/br/com/academiadev/suicidesquad/entity/Usuario.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/entity/Usuario.java
@@ -44,7 +44,8 @@ public class Usuario extends AuditableEntity<Long> implements UserDetails {
 
     @NotNull
     @Convert(converter = SexoUsuarioConverter.class)
-    private SexoUsuario sexo;
+    @Builder.Default
+    private SexoUsuario sexo = SexoUsuario.NAO_INFORMADO;
 
     @NotNull
     @JsonProperty("data_nascimento")

--- a/src/main/java/br/com/academiadev/suicidesquad/repository/UsuarioRepository.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/repository/UsuarioRepository.java
@@ -10,4 +10,5 @@ import java.util.Optional;
 @Repository
 public interface UsuarioRepository extends JpaRepository<Usuario, Long> {
     Optional<Usuario> findByEmail(String email);
+    Optional<Usuario> findByFacebookUserId(String facebookUserId);
 }

--- a/src/main/java/br/com/academiadev/suicidesquad/service/FacebookService.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/service/FacebookService.java
@@ -1,0 +1,61 @@
+package br.com.academiadev.suicidesquad.service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.social.facebook.api.Facebook;
+import org.springframework.social.facebook.api.User;
+import org.springframework.social.facebook.api.impl.FacebookTemplate;
+import org.springframework.social.facebook.connect.FacebookConnectionFactory;
+import org.springframework.social.oauth2.AccessGrant;
+import org.springframework.social.oauth2.OAuth2Operations;
+import org.springframework.social.oauth2.OAuth2Parameters;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+public class FacebookService {
+    @Value("${app.social.facebook.app-id:}")
+    private String appId;
+
+    @Value("${app.social.facebook.app-secret:}")
+    private String appSecret;
+
+    @Value("${app.social.facebook.backend-redirect-uri:}")
+    private String backendRedirectUri;
+
+    public String createAuthorizationURL() {
+        FacebookConnectionFactory connectionFactory = new FacebookConnectionFactory(appId, appSecret);
+        OAuth2Operations ops = connectionFactory.getOAuthOperations();
+
+        OAuth2Parameters params = new OAuth2Parameters();
+        params.setRedirectUri(backendRedirectUri);
+        params.setScope("public_profile,email,user_gender");
+        return ops.buildAuthorizeUrl(params);
+    }
+
+    public Optional<String> getAccessToken(String code) {
+        FacebookConnectionFactory connectionFactory = new FacebookConnectionFactory(appId, appSecret);
+        AccessGrant accessGrant = connectionFactory.getOAuthOperations().exchangeForAccess(
+                code,
+                backendRedirectUri,
+                null);
+        return Optional.ofNullable(accessGrant.getAccessToken());
+    }
+
+    public Optional<User> getUser(String accessToken) {
+        Facebook facebook = new FacebookTemplate(accessToken);
+        String[] fields = {
+                "id",
+                "first_name",
+                "last_name",
+                "middle_name",
+                "name",
+                "name_format",
+                "picture",
+                "short_name",
+                "email",
+                "gender"
+        };
+        return Optional.ofNullable(facebook.fetchObject("me", User.class, fields));
+    }
+}

--- a/src/main/java/br/com/academiadev/suicidesquad/service/UsuarioService.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/service/UsuarioService.java
@@ -31,4 +31,7 @@ public class UsuarioService {
     }
 
 
+    public Optional<Usuario> findByFacebookUserId(String facebookUserId) {
+        return usuarioRepository.findByFacebookUserId(facebookUserId);
+    }
 }

--- a/src/main/java/br/com/academiadev/suicidesquad/service/UsuarioService.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/service/UsuarioService.java
@@ -32,6 +32,9 @@ public class UsuarioService {
 
 
     public Optional<Usuario> findByFacebookUserId(String facebookUserId) {
+        if (facebookUserId == null) {
+            return Optional.empty();
+        }
         return usuarioRepository.findByFacebookUserId(facebookUserId);
     }
 }

--- a/src/main/resources/application-dev.properties.sample
+++ b/src/main/resources/application-dev.properties.sample
@@ -1,1 +1,4 @@
 security.jwt.token.secret-key=
+app.social.facebook.enabled = true
+app.social.facebook.app-id=
+app.social.facebook.app-secret=

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,4 +2,5 @@ spring.profiles.active=dev
 spring.datasource.url=jdbc:h2:~/test;AUTO_SERVER=TRUE
 
 app.social.facebook.enabled = false
-app.social.facebook.redirect-uri=http://localhost:8080/facebook/callback
+app.social.facebook.backend-redirect-uri=http://localhost:8080/facebook/callback
+app.social.facebook.frontend-redirect-uri=http://localhost:8081/

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,5 @@
 spring.profiles.active=dev
 spring.datasource.url=jdbc:h2:~/test;AUTO_SERVER=TRUE
+
+app.social.facebook.enabled = false
+app.social.facebook.redirect-uri=http://localhost:8080/facebook/callback

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,5 +2,5 @@ spring.profiles.active=dev
 spring.datasource.url=jdbc:h2:~/test;AUTO_SERVER=TRUE
 
 app.social.facebook.enabled = false
-app.social.facebook.backend-redirect-uri=http://localhost:8080/facebook/callback
+app.social.facebook.backend-redirect-uri=http://localhost:8080/auth/facebook/callback
 app.social.facebook.frontend-redirect-uri=http://localhost:8081/


### PR DESCRIPTION
Closes #31

# O que foi feito

- Adicionado valor padrão para o sexo do usuário

- Adicionado campo `facebookUserId` no usuário, e busca por ele ao repositório e serviço

- Adicionadas propriedades para as URL de _redirect_ do processo de autenticação

- Adicionado exemplo de arquivo de propriedades específicas para desenvolvimento, com chaves secretas

- Adicionadas dependências ao Spring Social Core e Spring Social Facebook

- Adicionar controlador de autenticação com o Facebook

# Por que foi feito

Para que o frontend possa disponibilizar um botão para login com o Facebook.

# O que falta fazer

É possível que um usuário do Facebook não tenha um email cadastrado. Nesse caso, precisamos receber este email uma etapa extra do cadastro. Devemos tratar isso na issue #57.