### PR TITLE
Atualizar dependências

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
 	ext {
-		springBootVersion = '2.0.7.BUILD-SNAPSHOT'
+		springBootVersion = '2.1.0.RELEASE'
 	}
 	repositories {
 		mavenCentral()

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.8.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip


### PR DESCRIPTION
Closes #52

# O que foi feito

- Gradle wrapper atualizado para 4.10.2
- Spring Boot atualizado para 2.1.0.RELEASE

# Por que foi feito

Para manter a atualidade destas dependências, e deixar de usar uma versão _snapshot_ do Spring Boot.