### PR TITLE
Deleção de pets

### DIFF
--- a/src/main/java/br/com/academiadev/suicidesquad/controller/PetController.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/controller/PetController.java
@@ -3,12 +3,16 @@ package br.com.academiadev.suicidesquad.controller;
 import br.com.academiadev.suicidesquad.dto.PetCreateDTO;
 import br.com.academiadev.suicidesquad.dto.PetDTO;
 import br.com.academiadev.suicidesquad.dto.PetDetailDTO;
+import br.com.academiadev.suicidesquad.entity.Pet;
 import br.com.academiadev.suicidesquad.entity.PetSearch;
+import br.com.academiadev.suicidesquad.entity.Usuario;
 import br.com.academiadev.suicidesquad.exception.ResourceNotFoundException;
 import br.com.academiadev.suicidesquad.mapper.PetMapper;
 import br.com.academiadev.suicidesquad.service.PetService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
@@ -44,5 +48,18 @@ public class PetController {
                 .findById(idPet)
                 .map(petMapper::toDetailDto)
                 .orElseThrow(() -> new ResourceNotFoundException("Pet com o id " + idPet + " não foi encontrado"));
+    }
+
+    @DeleteMapping("/pets/{idPet}")
+    public ResponseEntity deletePet(@PathVariable Long idPet, @AuthenticationPrincipal Usuario usuarioLogado) {
+        final Pet pet = petService.findById(idPet).orElse(null);
+        if (pet == null) {
+            return ResponseEntity.notFound().build();
+        }
+        if (!pet.getUsuario().getId().equals(usuarioLogado.getId())) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        }
+        petService.deleteById(idPet);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/br/com/academiadev/suicidesquad/controller/UsuarioController.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/controller/UsuarioController.java
@@ -11,6 +11,8 @@ import io.swagger.annotations.ApiResponses;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.rest.webmvc.ResourceNotFoundException;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
@@ -51,5 +53,16 @@ public class UsuarioController {
     UsuarioDTO createUsuario(@Valid @RequestBody UsuarioCreateDTO usuarioCreateDTO) {
         Usuario usuario = usuarioMapper.toEntity(usuarioCreateDTO);
         return usuarioMapper.toDto(usuarioService.save(usuario));
+    }
+
+    @DeleteMapping("/usuarios/{idUsuario}")
+    public ResponseEntity deleteUsuario(@PathVariable Long idUsuario, @AuthenticationPrincipal Usuario usuarioLogado) {
+        if (!usuarioLogado.getId().equals(idUsuario)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        }
+        if (usuarioService.existsById(idUsuario)) {
+            usuarioService.deleteById(idUsuario);
+        }
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/br/com/academiadev/suicidesquad/entity/PetSearch.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/entity/PetSearch.java
@@ -14,6 +14,8 @@ public class PetSearch {
 
     private SexoPet sexo;
 
+    private Boolean mostrarEntregues;
+
     private Set<Porte> portes = new HashSet<>();
 
     private Set<Raca> racas = new HashSet<>();
@@ -28,9 +30,10 @@ public class PetSearch {
 
     private Set<Cor> cores = new HashSet<>();
 
-    public PetSearch(@NotNull Tipo tipo, SexoPet sexo, Set<Porte> portes, Set<Raca> racas, Set<ComprimentoPelo> pelos, Set<Categoria> categorias, Set<Vacinacao> vacinacoes, Set<Castracao> castracoes, Set<Cor> cores) {
+    public PetSearch(@NotNull Tipo tipo, SexoPet sexo, Boolean mostrarEntregues, Set<Porte> portes, Set<Raca> racas, Set<ComprimentoPelo> pelos, Set<Categoria> categorias, Set<Vacinacao> vacinacoes, Set<Castracao> castracoes, Set<Cor> cores) {
         this.tipo = tipo;
         this.sexo = sexo;
+        this.mostrarEntregues = mostrarEntregues != null && mostrarEntregues;
 
         if (portes != null) this.portes = portes;
         if (racas != null) this.racas = racas;

--- a/src/main/java/br/com/academiadev/suicidesquad/service/PetService.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/service/PetService.java
@@ -99,4 +99,12 @@ public class PetService {
 
         return petRepository.findAll(builder);
     }
+
+    public boolean existsById(Long idPet) {
+        return petRepository.existsById(idPet);
+    }
+
+    public void deleteById(Long idPet) {
+        petRepository.deleteById(idPet);
+    }
 }

--- a/src/main/java/br/com/academiadev/suicidesquad/service/UsuarioService.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/service/UsuarioService.java
@@ -36,4 +36,12 @@ public class UsuarioService {
         }
         return usuarioRepository.findByFacebookUserId(facebookUserId);
     }
+
+    public boolean existsById(Long idUsuario) {
+        return usuarioRepository.existsById(idUsuario);
+    }
+
+    public void deleteById(Long idUsuario) {
+        usuarioRepository.deleteById(idUsuario);
+    }
 }


### PR DESCRIPTION
Closes #26.

# O que foi feito

* Adicionada filtragem para excluir pets com a situação de `ENTREGA` da pesquisa.
* Adicionado o parâmetro booleano opcional "mostrarEntregues" à pesquisa, para voltar a incluir estes pets.
* Adicionados endpoints de `DELETE /usuarios/{idUsuario}` e `DELETE /pets/{idPet}` para fazer o _hard delete_. Apenas o usuário certo pode fazer estas ações (próprio usuário, e o publicador do pet, respectivamente).

# Por que foi feito

Para remover itens irrelevantes da pesquisa, e permitir que o usuário remova suas informações do sistema.