### PR TITLE
Edição do pet e do usuário

### DIFF
--- a/src/main/java/br/com/academiadev/suicidesquad/config/SecurityConfig.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/config/SecurityConfig.java
@@ -9,12 +9,14 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.config.http.SessionCreationPolicy;
 
 @SuppressWarnings("SpringJavaAutowiredFieldsWarningInspection")
 @Configuration
+@EnableGlobalMethodSecurity(prePostEnabled = true)
 public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
     @Autowired

--- a/src/main/java/br/com/academiadev/suicidesquad/config/SwaggerConfig.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/config/SwaggerConfig.java
@@ -2,6 +2,7 @@ package br.com.academiadev.suicidesquad.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import springfox.documentation.builders.ParameterBuilder;
 import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.builders.RequestHandlerSelectors;
@@ -30,6 +31,7 @@ public class SwaggerConfig {
                 .paths(PathSelectors.any())
                 .build()
                 .apiInfo(apiInfo())
+                .ignoredParameterTypes(AuthenticationPrincipal.class)
                 .useDefaultResponseMessages(false);
     }
 

--- a/src/main/java/br/com/academiadev/suicidesquad/controller/PetController.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/controller/PetController.java
@@ -3,11 +3,14 @@ package br.com.academiadev.suicidesquad.controller;
 import br.com.academiadev.suicidesquad.dto.PetCreateDTO;
 import br.com.academiadev.suicidesquad.dto.PetDTO;
 import br.com.academiadev.suicidesquad.dto.PetDetailDTO;
+import br.com.academiadev.suicidesquad.dto.RegistroCreateDTO;
 import br.com.academiadev.suicidesquad.entity.Pet;
 import br.com.academiadev.suicidesquad.entity.PetSearch;
+import br.com.academiadev.suicidesquad.entity.Registro;
 import br.com.academiadev.suicidesquad.entity.Usuario;
 import br.com.academiadev.suicidesquad.exception.ResourceNotFoundException;
 import br.com.academiadev.suicidesquad.mapper.PetMapper;
+import br.com.academiadev.suicidesquad.mapper.RegistroMapper;
 import br.com.academiadev.suicidesquad.service.PetService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -25,10 +28,13 @@ public class PetController {
 
     private final PetMapper petMapper;
 
+    private final RegistroMapper registroMapper;
+
     @Autowired
-    public PetController(PetService petService, PetMapper petMapper) {
+    public PetController(PetService petService, PetMapper petMapper, RegistroMapper registroMapper) {
         this.petService = petService;
         this.petMapper = petMapper;
+        this.registroMapper = registroMapper;
     }
 
     @GetMapping("/pets/search")
@@ -74,6 +80,19 @@ public class PetController {
         }
         petMapper.updateEntity(petCreateDTO, pet);
         petService.save(pet);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/pets/{idPet}/registros")
+    public ResponseEntity addRegistro(@PathVariable Long idPet, @Valid @RequestBody RegistroCreateDTO registroCreateDTO, @AuthenticationPrincipal Usuario usuarioLogado) {
+        Pet pet = petService.findById(idPet).orElse(null);
+        if (pet == null) {
+            return ResponseEntity.notFound().build();
+        }
+        if (!pet.getUsuario().getId().equals(usuarioLogado.getId())) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        }
+        pet.addRegistro(registroMapper.toEntity(registroCreateDTO));
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/br/com/academiadev/suicidesquad/controller/PetController.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/controller/PetController.java
@@ -3,12 +3,16 @@ package br.com.academiadev.suicidesquad.controller;
 import br.com.academiadev.suicidesquad.dto.PetCreateDTO;
 import br.com.academiadev.suicidesquad.dto.PetDTO;
 import br.com.academiadev.suicidesquad.dto.PetDetailDTO;
+import br.com.academiadev.suicidesquad.entity.Pet;
 import br.com.academiadev.suicidesquad.entity.PetSearch;
+import br.com.academiadev.suicidesquad.entity.Usuario;
 import br.com.academiadev.suicidesquad.exception.ResourceNotFoundException;
 import br.com.academiadev.suicidesquad.mapper.PetMapper;
 import br.com.academiadev.suicidesquad.service.PetService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
@@ -44,5 +48,18 @@ public class PetController {
                 .findById(idPet)
                 .map(petMapper::toDetailDto)
                 .orElseThrow(() -> new ResourceNotFoundException("Pet com o id " + idPet + " não foi encontrado"));
+    }
+
+    @DeleteMapping("/pets/{idPet}")
+    public ResponseEntity deletePet(@PathVariable Long idPet, @AuthenticationPrincipal Usuario usuarioLogado) {
+        final Pet pet = petService.findById(idPet).orElse(null);
+        if (pet == null) {
+            return ResponseEntity.notFound().build();
+        }
+        if (!pet.getUsuario().getId().equals(usuarioLogado.getId())) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        }
+        petService.deleteById(idPet);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/br/com/academiadev/suicidesquad/controller/PetController.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/controller/PetController.java
@@ -62,4 +62,18 @@ public class PetController {
         petService.deleteById(idPet);
         return ResponseEntity.ok().build();
     }
+
+    @PutMapping("/pets/{idPet}")
+    public ResponseEntity editPet(@PathVariable Long idPet, @Valid @RequestBody PetCreateDTO petCreateDTO, @AuthenticationPrincipal Usuario usuarioLogado) {
+        final Pet pet = petService.findById(idPet).orElse(null);
+        if (pet == null) {
+            return ResponseEntity.notFound().build();
+        }
+        if (!pet.getUsuario().getId().equals(usuarioLogado.getId())) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        }
+        final Pet petAtualizado = petMapper.updateEntity(petCreateDTO, pet);
+        petService.save(petAtualizado);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/br/com/academiadev/suicidesquad/controller/PetController.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/controller/PetController.java
@@ -15,6 +15,7 @@ import br.com.academiadev.suicidesquad.service.PetService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -57,26 +58,22 @@ public class PetController {
     }
 
     @DeleteMapping("/pets/{idPet}")
-    public ResponseEntity deletePet(@PathVariable Long idPet, @AuthenticationPrincipal Usuario usuarioLogado) {
+    @PreAuthorize("@petService.isPublicador(authentication, #idPet)")
+    public ResponseEntity deletePet(@PathVariable Long idPet) {
         final Pet pet = petService.findById(idPet).orElse(null);
         if (pet == null) {
             return ResponseEntity.notFound().build();
-        }
-        if (!pet.getUsuario().getId().equals(usuarioLogado.getId())) {
-            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         }
         petService.deleteById(idPet);
         return ResponseEntity.ok().build();
     }
 
     @PutMapping("/pets/{idPet}")
-    public ResponseEntity editPet(@PathVariable Long idPet, @Valid @RequestBody PetCreateDTO petCreateDTO, @AuthenticationPrincipal Usuario usuarioLogado) {
+    @PreAuthorize("@petService.isPublicador(authentication, #idPet)")
+    public ResponseEntity editPet(@PathVariable Long idPet, @Valid @RequestBody PetCreateDTO petCreateDTO) {
         Pet pet = petService.findById(idPet).orElse(null);
         if (pet == null) {
             return ResponseEntity.notFound().build();
-        }
-        if (!pet.getUsuario().getId().equals(usuarioLogado.getId())) {
-            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         }
         petMapper.updateEntity(petCreateDTO, pet);
         petService.save(pet);
@@ -84,13 +81,11 @@ public class PetController {
     }
 
     @PostMapping("/pets/{idPet}/registros")
-    public ResponseEntity addRegistro(@PathVariable Long idPet, @Valid @RequestBody RegistroCreateDTO registroCreateDTO, @AuthenticationPrincipal Usuario usuarioLogado) {
+    @PreAuthorize("@petService.isPublicador(authentication, #idPet)")
+    public ResponseEntity addRegistro(@PathVariable Long idPet, @Valid @RequestBody RegistroCreateDTO registroCreateDTO) {
         Pet pet = petService.findById(idPet).orElse(null);
         if (pet == null) {
             return ResponseEntity.notFound().build();
-        }
-        if (!pet.getUsuario().getId().equals(usuarioLogado.getId())) {
-            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         }
         pet.addRegistro(registroMapper.toEntity(registroCreateDTO));
         return ResponseEntity.ok().build();

--- a/src/main/java/br/com/academiadev/suicidesquad/controller/PetController.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/controller/PetController.java
@@ -65,15 +65,15 @@ public class PetController {
 
     @PutMapping("/pets/{idPet}")
     public ResponseEntity editPet(@PathVariable Long idPet, @Valid @RequestBody PetCreateDTO petCreateDTO, @AuthenticationPrincipal Usuario usuarioLogado) {
-        final Pet pet = petService.findById(idPet).orElse(null);
+        Pet pet = petService.findById(idPet).orElse(null);
         if (pet == null) {
             return ResponseEntity.notFound().build();
         }
         if (!pet.getUsuario().getId().equals(usuarioLogado.getId())) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         }
-        final Pet petAtualizado = petMapper.updateEntity(petCreateDTO, pet);
-        petService.save(petAtualizado);
+        petMapper.updateEntity(petCreateDTO, pet);
+        petService.save(pet);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/br/com/academiadev/suicidesquad/controller/UsuarioController.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/controller/UsuarioController.java
@@ -75,9 +75,8 @@ public class UsuarioController {
         if (!usuarioService.existsById(idUsuario)) {
             return ResponseEntity.notFound().build();
         }
-        final Usuario usuario = usuarioMapper.updateEntity(usuarioEditDTO, usuarioLogado);
-        usuario.setId(idUsuario);
-        usuarioService.save(usuario);
+        usuarioMapper.updateEntity(usuarioEditDTO, usuarioLogado);
+        usuarioService.save(usuarioLogado);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/br/com/academiadev/suicidesquad/controller/UsuarioController.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/controller/UsuarioController.java
@@ -2,6 +2,7 @@ package br.com.academiadev.suicidesquad.controller;
 
 import br.com.academiadev.suicidesquad.dto.UsuarioCreateDTO;
 import br.com.academiadev.suicidesquad.dto.UsuarioDTO;
+import br.com.academiadev.suicidesquad.dto.UsuarioEditDTO;
 import br.com.academiadev.suicidesquad.entity.Usuario;
 import br.com.academiadev.suicidesquad.mapper.UsuarioMapper;
 import br.com.academiadev.suicidesquad.service.UsuarioService;
@@ -63,6 +64,20 @@ public class UsuarioController {
         if (usuarioService.existsById(idUsuario)) {
             usuarioService.deleteById(idUsuario);
         }
+        return ResponseEntity.ok().build();
+    }
+
+    @PutMapping("/usuarios/{idUsuario}")
+    public ResponseEntity editUsuario(@PathVariable Long idUsuario, @Valid @RequestBody UsuarioEditDTO usuarioEditDTO, @AuthenticationPrincipal Usuario usuarioLogado) {
+        if (!usuarioLogado.getId().equals(idUsuario)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        }
+        if (!usuarioService.existsById(idUsuario)) {
+            return ResponseEntity.notFound().build();
+        }
+        final Usuario usuario = usuarioMapper.updateEntity(usuarioEditDTO, usuarioLogado);
+        usuario.setId(idUsuario);
+        usuarioService.save(usuario);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/br/com/academiadev/suicidesquad/controller/UsuarioController.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/controller/UsuarioController.java
@@ -11,6 +11,8 @@ import io.swagger.annotations.ApiResponses;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.rest.webmvc.ResourceNotFoundException;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
@@ -51,5 +53,16 @@ public class UsuarioController {
     UsuarioDTO createUsuario(@Valid @RequestBody UsuarioCreateDTO usuarioCreateDTO) {
         Usuario usuario = usuarioMapper.toEntity(usuarioCreateDTO);
         return usuarioMapper.toDto(usuarioService.save(usuario));
+    }
+
+    @DeleteMapping("/usuarios/{idUsuario}")
+    public ResponseEntity deleteUsuario(@PathVariable Long idUsuario, @AuthenticationPrincipal Usuario usuarioLogado) {
+        if (!usuarioLogado.getId().equals(idUsuario)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        }
+        if (usuarioService.existsById(idUsuario)) {
+            usuarioService.deleteById(idUsuario);
+        }
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/br/com/academiadev/suicidesquad/dto/RegistroCreateDTO.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/dto/RegistroCreateDTO.java
@@ -1,0 +1,16 @@
+package br.com.academiadev.suicidesquad.dto;
+
+import br.com.academiadev.suicidesquad.enums.Situacao;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotNull;
+
+@Data
+@NoArgsConstructor
+public class RegistroCreateDTO {
+    @ApiModelProperty(value = "Situação", allowableValues = "PROCURANDO,ENCONTRADO,ENTREGUE")
+    @NotNull
+    private Situacao situacao;
+}

--- a/src/main/java/br/com/academiadev/suicidesquad/dto/TelefoneDTO.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/dto/TelefoneDTO.java
@@ -1,0 +1,18 @@
+package br.com.academiadev.suicidesquad.dto;
+
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotNull;
+
+@Data
+@NoArgsConstructor
+public class TelefoneDTO {
+    @ApiModelProperty(value = "Número", example = "(47) 99999-9999")
+    @NotNull
+    private String numero;
+
+    @ApiModelProperty(value = "Tem WhatsApp?", example = "true")
+    private boolean whatsapp;
+}

--- a/src/main/java/br/com/academiadev/suicidesquad/dto/UsuarioCreateDTO.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/dto/UsuarioCreateDTO.java
@@ -4,6 +4,7 @@ import io.swagger.annotations.ApiModelProperty;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import javax.validation.constraints.Email;
 import javax.validation.constraints.NotNull;
 
 @Data
@@ -15,6 +16,7 @@ public class UsuarioCreateDTO {
 
     @ApiModelProperty(value = "E-mail", example = "fulano@example.com", required = true)
     @NotNull
+    @Email
     private String email;
 
     @ApiModelProperty(value = "Senha", required = true)

--- a/src/main/java/br/com/academiadev/suicidesquad/dto/UsuarioEditDTO.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/dto/UsuarioEditDTO.java
@@ -1,0 +1,37 @@
+package br.com.academiadev.suicidesquad.dto;
+
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotNull;
+import java.util.Set;
+
+@Data
+@NoArgsConstructor
+public class UsuarioEditDTO {
+    @ApiModelProperty(value = "Nome", example = "Fulano", required = true)
+    @NotNull
+    private String nome;
+
+    @ApiModelProperty(value = "E-mail", example = "fulano@example.com", required = true)
+    @NotNull
+    @Email
+    private String email;
+
+    @ApiModelProperty(value = "Senha")
+    private String senha;
+
+    @ApiModelProperty(value = "Sexo", allowableValues = "NAO_INFORMADO,MASCULINO,FEMININO")
+    private String sexo;
+
+    @ApiModelProperty(value = "Data de nascimento", example = "2018-01-01")
+    private String data_nascimento;
+
+    @ApiModelProperty(value = "Localização")
+    private LocalizacaoDTO localizacao;
+
+    @ApiModelProperty(value = "Telefones")
+    private Set<TelefoneDTO> telefones;
+}

--- a/src/main/java/br/com/academiadev/suicidesquad/entity/Localizacao.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/entity/Localizacao.java
@@ -1,15 +1,17 @@
 package br.com.academiadev.suicidesquad.entity;
 
-import lombok.Data;
-import lombok.EqualsAndHashCode;
+import lombok.*;
 
 import javax.persistence.Entity;
 import javax.persistence.Table;
 import javax.validation.constraints.NotBlank;
 
 @Entity
+@Builder
 @Table(name = "localizacao")
 @Data
+@NoArgsConstructor
+@AllArgsConstructor
 @EqualsAndHashCode(callSuper = true)
 public class Localizacao extends BaseEntity<Long> {
     @NotBlank

--- a/src/main/java/br/com/academiadev/suicidesquad/entity/Pet.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/entity/Pet.java
@@ -57,11 +57,15 @@ public class Pet extends AuditableEntity<Long> {
     @ElementCollection(targetClass = Cor.class)
     @CollectionTable(name = "pet_cor")
     @Convert(converter = CorConverter.class)
-    @Singular("cor")
+    @Builder.Default
     private Set<Cor> cores = new HashSet<>();
 
-    @OneToMany(mappedBy = "pet", orphanRemoval = true)
-    @Singular
+    @OneToMany(
+            mappedBy = "pet",
+            cascade = CascadeType.ALL,
+            orphanRemoval = true
+    )
+    @Builder.Default
     private List<Registro> registros = new ArrayList<>();
 
     @Size(min = 2, max = 80)

--- a/src/main/java/br/com/academiadev/suicidesquad/entity/PetSearch.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/entity/PetSearch.java
@@ -14,6 +14,8 @@ public class PetSearch {
 
     private SexoPet sexo;
 
+    private Boolean mostrarEntregues;
+
     private Set<Porte> portes = new HashSet<>();
 
     private Set<Raca> racas = new HashSet<>();
@@ -28,9 +30,10 @@ public class PetSearch {
 
     private Set<Cor> cores = new HashSet<>();
 
-    public PetSearch(@NotNull Tipo tipo, SexoPet sexo, Set<Porte> portes, Set<Raca> racas, Set<ComprimentoPelo> pelos, Set<Categoria> categorias, Set<Vacinacao> vacinacoes, Set<Castracao> castracoes, Set<Cor> cores) {
+    public PetSearch(@NotNull Tipo tipo, SexoPet sexo, Boolean mostrarEntregues, Set<Porte> portes, Set<Raca> racas, Set<ComprimentoPelo> pelos, Set<Categoria> categorias, Set<Vacinacao> vacinacoes, Set<Castracao> castracoes, Set<Cor> cores) {
         this.tipo = tipo;
         this.sexo = sexo;
+        this.mostrarEntregues = mostrarEntregues != null && mostrarEntregues;
 
         if (portes != null) this.portes = portes;
         if (racas != null) this.racas = racas;

--- a/src/main/java/br/com/academiadev/suicidesquad/entity/Telefone.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/entity/Telefone.java
@@ -3,23 +3,19 @@ package br.com.academiadev.suicidesquad.entity;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.OnDelete;
-import org.hibernate.annotations.OnDeleteAction;
 
-import javax.persistence.Entity;
-import javax.persistence.ManyToOne;
-import javax.persistence.Table;
+import javax.persistence.*;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 
 @Entity
 @Table(name = "telefone")
 @Data
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = true, exclude = "usuario")
 @NoArgsConstructor
 public class Telefone extends BaseEntity<Long> {
-    @ManyToOne(optional = false)
-    @OnDelete(action = OnDeleteAction.NO_ACTION)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "usuario_id")
     private Usuario usuario;
 
     @NotBlank

--- a/src/main/java/br/com/academiadev/suicidesquad/entity/Telefone.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/entity/Telefone.java
@@ -4,7 +4,10 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
-import javax.persistence.*;
+import javax.persistence.Entity;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 
@@ -14,7 +17,7 @@ import javax.validation.constraints.NotNull;
 @EqualsAndHashCode(callSuper = true, exclude = "usuario")
 @NoArgsConstructor
 public class Telefone extends BaseEntity<Long> {
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne
     @JoinColumn(name = "usuario_id")
     private Usuario usuario;
 

--- a/src/main/java/br/com/academiadev/suicidesquad/entity/Usuario.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/entity/Usuario.java
@@ -4,8 +4,6 @@ import br.com.academiadev.suicidesquad.converter.SexoUsuarioConverter;
 import br.com.academiadev.suicidesquad.enums.SexoUsuario;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.*;
-import org.hibernate.annotations.OnDelete;
-import org.hibernate.annotations.OnDeleteAction;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
@@ -49,9 +47,10 @@ public class Usuario extends AuditableEntity<Long> implements UserDetails {
 
     private String facebookUserId;
 
-    @ManyToOne(cascade = CascadeType.PERSIST)
-    @JoinColumn(name = "id_localizacao")
-    @OnDelete(action = OnDeleteAction.NO_ACTION)
+    @ManyToOne(
+            targetEntity = Localizacao.class,
+            cascade = CascadeType.PERSIST
+    )
     private Localizacao localizacao;
 
     @OneToMany(

--- a/src/main/java/br/com/academiadev/suicidesquad/entity/Usuario.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/entity/Usuario.java
@@ -54,8 +54,11 @@ public class Usuario extends AuditableEntity<Long> implements UserDetails {
     @OnDelete(action = OnDeleteAction.NO_ACTION)
     private Localizacao localizacao;
 
-    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
-    @Singular
+    @OneToMany(
+            mappedBy = "usuario",
+            cascade = CascadeType.ALL,
+            orphanRemoval = true)
+    @Builder.Default
     private List<Telefone> telefones = new ArrayList<>();
 
     @Builder.Default
@@ -81,7 +84,7 @@ public class Usuario extends AuditableEntity<Long> implements UserDetails {
         telefone.setUsuario(this);
     }
 
-    private void setTelefones(List<Telefone> telefones) {
+    public void setTelefones(List<Telefone> telefones) {
         telefones.forEach(this::addTelefone);
     }
 

--- a/src/main/java/br/com/academiadev/suicidesquad/entity/Usuario.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/entity/Usuario.java
@@ -57,7 +57,8 @@ public class Usuario extends AuditableEntity<Long> implements UserDetails {
     @OneToMany(
             mappedBy = "usuario",
             cascade = CascadeType.ALL,
-            orphanRemoval = true)
+            orphanRemoval = true,
+            fetch = FetchType.EAGER)
     @Builder.Default
     private List<Telefone> telefones = new ArrayList<>();
 
@@ -85,7 +86,11 @@ public class Usuario extends AuditableEntity<Long> implements UserDetails {
     }
 
     public void setTelefones(List<Telefone> telefones) {
-        telefones.forEach(this::addTelefone);
+        if (telefones == null || telefones.size() == 0) {
+            this.telefones.clear();
+        } else {
+            telefones.forEach(this::addTelefone);
+        }
     }
 
     @Override

--- a/src/main/java/br/com/academiadev/suicidesquad/mapper/LocalizacaoMapper.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/mapper/LocalizacaoMapper.java
@@ -24,5 +24,4 @@ public interface LocalizacaoMapper {
     LocalizacaoDTO toDto(Localizacao entity);
 
     List<LocalizacaoDTO> toDtos(List<Localizacao> entities);
-
 }

--- a/src/main/java/br/com/academiadev/suicidesquad/mapper/PetMapper.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/mapper/PetMapper.java
@@ -35,6 +35,22 @@ public abstract class PetMapper {
     public abstract List<Pet> toEntities(List<PetCreateDTO> dtos);
 
     @Mappings({
+            @Mapping(target = "tipo"),
+            @Mapping(target = "porte"),
+            @Mapping(target = "raca", ignore = true),
+            @Mapping(target = "comprimentoPelo", source = "comprimento_pelo"),
+            @Mapping(target = "sexo"),
+            @Mapping(target = "categoria"),
+            @Mapping(target = "vacinacao"),
+            @Mapping(target = "castracao"),
+            @Mapping(target = "nome"),
+            @Mapping(target = "cores"),
+            @Mapping(target = "localizacao"),
+            @Mapping(target = "descricao")
+    })
+    public abstract Pet updateEntity(PetCreateDTO petCreateDTO, @MappingTarget Pet pet);
+
+    @Mappings({
             @Mapping(target = "data_criacao", source = "createdDate"),
             @Mapping(target = "data_edicao", source = "lastModifiedDate"),
             @Mapping(target = "tipo"),

--- a/src/main/java/br/com/academiadev/suicidesquad/mapper/PetMapper.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/mapper/PetMapper.java
@@ -1,12 +1,15 @@
 package br.com.academiadev.suicidesquad.mapper;
 
+import br.com.academiadev.suicidesquad.dto.LocalizacaoDTO;
 import br.com.academiadev.suicidesquad.dto.PetCreateDTO;
 import br.com.academiadev.suicidesquad.dto.PetDTO;
 import br.com.academiadev.suicidesquad.dto.PetDetailDTO;
 import br.com.academiadev.suicidesquad.entity.Pet;
 import br.com.academiadev.suicidesquad.enums.Raca;
 import br.com.academiadev.suicidesquad.enums.Tipo;
+import br.com.academiadev.suicidesquad.service.LocalizacaoService;
 import org.mapstruct.*;
+import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.List;
 
@@ -16,6 +19,10 @@ import java.util.List;
         uses = {LocalizacaoMapper.class, RegistroMapper.class}
 )
 public abstract class PetMapper {
+
+    @Autowired
+    private LocalizacaoService localizacaoService;
+
     @Mappings({
             @Mapping(target = "tipo"),
             @Mapping(target = "porte"),
@@ -27,7 +34,7 @@ public abstract class PetMapper {
             @Mapping(target = "castracao", defaultValue = "NAO_INFORMADO"),
             @Mapping(target = "nome"),
             @Mapping(target = "cores"),
-            @Mapping(target = "localizacao"),
+            @Mapping(target = "localizacao", ignore = true),
             @Mapping(target = "descricao")
     })
     public abstract Pet toEntity(PetCreateDTO dto);
@@ -45,7 +52,7 @@ public abstract class PetMapper {
             @Mapping(target = "castracao"),
             @Mapping(target = "nome"),
             @Mapping(target = "cores"),
-            @Mapping(target = "localizacao"),
+            @Mapping(target = "localizacao", ignore = true),
             @Mapping(target = "descricao")
     })
     public abstract Pet updateEntity(PetCreateDTO petCreateDTO, @MappingTarget Pet pet);
@@ -115,6 +122,20 @@ public abstract class PetMapper {
             entity.setRaca(Raca.EQUINO_SRD);
         } else {
             throw new RuntimeException("Tipo de pet inválido");
+        }
+    }
+
+    @AfterMapping
+    public void mapearLocalizacao(PetCreateDTO dto, @MappingTarget Pet entity) {
+        final LocalizacaoDTO localizacaoDTO = dto.getLocalizacao();
+        if (localizacaoDTO != null) {
+            entity.setLocalizacao(localizacaoService.findOrCreate(
+                    localizacaoDTO.getBairro(),
+                    localizacaoDTO.getCidade(),
+                    localizacaoDTO.getUf()
+            ));
+        } else {
+            entity.setLocalizacao(null);
         }
     }
 }

--- a/src/main/java/br/com/academiadev/suicidesquad/mapper/RegistroMapper.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/mapper/RegistroMapper.java
@@ -1,14 +1,18 @@
 package br.com.academiadev.suicidesquad.mapper;
 
+import br.com.academiadev.suicidesquad.dto.RegistroCreateDTO;
 import br.com.academiadev.suicidesquad.dto.RegistroDTO;
 import br.com.academiadev.suicidesquad.entity.Registro;
 import org.mapstruct.*;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Mapper(
         componentModel = "spring",
-        unmappedTargetPolicy = ReportingPolicy.IGNORE
+        unmappedTargetPolicy = ReportingPolicy.IGNORE,
+        uses = {LocalDateTime.class}
 )
 public interface RegistroMapper {
     @Mappings({
@@ -17,7 +21,11 @@ public interface RegistroMapper {
     })
     Registro toEntity(RegistroDTO dto);
 
-    List<Registro> toEntities(List<RegistroDTO> dtos);
+    @Mappings({
+            @Mapping(target = "situacao"),
+            @Mapping(target = "data", expression = "java(LocalDateTime.now())")
+    })
+    Registro toEntity(RegistroCreateDTO dto);
 
     @InheritInverseConfiguration
     RegistroDTO toDto(Registro entity);

--- a/src/main/java/br/com/academiadev/suicidesquad/mapper/TelefoneMapper.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/mapper/TelefoneMapper.java
@@ -1,0 +1,26 @@
+package br.com.academiadev.suicidesquad.mapper;
+
+import br.com.academiadev.suicidesquad.dto.TelefoneDTO;
+import br.com.academiadev.suicidesquad.entity.Telefone;
+import org.mapstruct.*;
+
+import java.util.List;
+
+@Mapper(
+        componentModel = "spring",
+        unmappedTargetPolicy = ReportingPolicy.IGNORE
+)
+public interface TelefoneMapper {
+    @Mappings({
+            @Mapping(target = "numero"),
+            @Mapping(target = "whatsapp", defaultValue = "false")
+    })
+    Telefone toEntity(TelefoneDTO dto);
+
+    List<Telefone> toEntities(List<TelefoneDTO> dtos);
+
+    @InheritInverseConfiguration
+    TelefoneDTO toDto(Telefone entity);
+
+    List<TelefoneDTO> toDtos(List<Telefone> dtos);
+}

--- a/src/main/java/br/com/academiadev/suicidesquad/mapper/UsuarioMapper.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/mapper/UsuarioMapper.java
@@ -1,11 +1,14 @@
 package br.com.academiadev.suicidesquad.mapper;
 
+import br.com.academiadev.suicidesquad.dto.LocalizacaoDTO;
 import br.com.academiadev.suicidesquad.dto.UsuarioCreateDTO;
 import br.com.academiadev.suicidesquad.dto.UsuarioDTO;
 import br.com.academiadev.suicidesquad.dto.UsuarioEditDTO;
 import br.com.academiadev.suicidesquad.entity.Usuario;
+import br.com.academiadev.suicidesquad.service.LocalizacaoService;
 import br.com.academiadev.suicidesquad.service.PasswordService;
 import org.mapstruct.*;
+import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.List;
 
@@ -15,24 +18,28 @@ import java.util.List;
         uses = {LocalizacaoMapper.class, TelefoneMapper.class}
 )
 public abstract class UsuarioMapper {
+
+    @Autowired
+    private LocalizacaoService localizacaoService;
+
     @Mappings({
             @Mapping(target = "nome"),
             @Mapping(target = "email"),
             @Mapping(target = "senha", ignore = true),
             @Mapping(target = "sexo", defaultValue = "NAO_INFORMADO"),
             @Mapping(target = "dataNascimento", source = "data_nascimento", dateFormat = "yyyy-MM-dd"),
-            @Mapping(target = "localizacao")
+            @Mapping(target = "localizacao", ignore = true)
     })
     public abstract Usuario toEntity(UsuarioCreateDTO dto);
 
     @Mappings({
-            @Mapping(target = "nome", source = "nome"),
-            @Mapping(target = "email", source = "email"),
+            @Mapping(target = "nome"),
+            @Mapping(target = "email"),
             @Mapping(target = "senha", ignore = true),
-            @Mapping(target = "sexo", source = "dto.sexo", defaultValue = "NAO_INFORMADO"),
+            @Mapping(target = "sexo", defaultValue = "NAO_INFORMADO"),
             @Mapping(target = "dataNascimento", source = "data_nascimento", dateFormat = "yyyy-MM-dd"),
-            @Mapping(target = "localizacao", source = "localizacao"),
-            @Mapping(target = "telefones", source = "telefones")
+            @Mapping(target = "localizacao", ignore = true),
+            @Mapping(target = "telefones")
     })
     public abstract Usuario updateEntity(UsuarioEditDTO dto, @MappingTarget Usuario entity);
 
@@ -61,5 +68,33 @@ public abstract class UsuarioMapper {
         entity.getTelefones().forEach(telefone -> {
             telefone.setUsuario(entity);
         });
+    }
+
+    @AfterMapping
+    public void mapearLocalizacao(UsuarioCreateDTO dto, @MappingTarget Usuario entity) {
+        final LocalizacaoDTO localizacaoDTO = dto.getLocalizacao();
+        if (localizacaoDTO != null) {
+            entity.setLocalizacao(localizacaoService.findOrCreate(
+                    localizacaoDTO.getBairro(),
+                    localizacaoDTO.getCidade(),
+                    localizacaoDTO.getUf()
+            ));
+        } else {
+            entity.setLocalizacao(null);
+        }
+    }
+
+    @AfterMapping
+    public void mapearLocalizacao(UsuarioEditDTO dto, @MappingTarget Usuario entity) {
+        final LocalizacaoDTO localizacaoDTO = dto.getLocalizacao();
+        if (localizacaoDTO != null) {
+            entity.setLocalizacao(localizacaoService.findOrCreate(
+                    localizacaoDTO.getBairro(),
+                    localizacaoDTO.getCidade(),
+                    localizacaoDTO.getUf()
+            ));
+        } else {
+            entity.setLocalizacao(null);
+        }
     }
 }

--- a/src/main/java/br/com/academiadev/suicidesquad/mapper/UsuarioMapper.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/mapper/UsuarioMapper.java
@@ -26,15 +26,15 @@ public abstract class UsuarioMapper {
     public abstract Usuario toEntity(UsuarioCreateDTO dto);
 
     @Mappings({
-            @Mapping(target = "nome"),
-            @Mapping(target = "email"),
+            @Mapping(target = "nome", source = "nome"),
+            @Mapping(target = "email", source = "email"),
             @Mapping(target = "senha", ignore = true),
-            @Mapping(target = "sexo", defaultValue = "NAO_INFORMADO"),
+            @Mapping(target = "sexo", source = "dto.sexo", defaultValue = "NAO_INFORMADO"),
             @Mapping(target = "dataNascimento", source = "data_nascimento", dateFormat = "yyyy-MM-dd"),
-            @Mapping(target = "localizacao"),
-            @Mapping(target = "telefones")
+            @Mapping(target = "localizacao", source = "localizacao"),
+            @Mapping(target = "telefones", source = "telefones")
     })
-    public abstract Usuario toEntity(UsuarioEditDTO dto);
+    public abstract Usuario updateEntity(UsuarioEditDTO dto, @MappingTarget Usuario entity);
 
     @Mappings({
             @Mapping(target = "nome"),
@@ -54,5 +54,12 @@ public abstract class UsuarioMapper {
         if (usuarioEditDTO.getSenha() != null) {
             entity.setSenha(PasswordService.encoder().encode(usuarioEditDTO.getSenha()));
         }
+    }
+
+    @AfterMapping
+    public void mapearRelacoes(UsuarioEditDTO dto, @MappingTarget Usuario entity) {
+        entity.getTelefones().forEach(telefone -> {
+            telefone.setUsuario(entity);
+        });
     }
 }

--- a/src/main/java/br/com/academiadev/suicidesquad/mapper/UsuarioMapper.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/mapper/UsuarioMapper.java
@@ -2,6 +2,7 @@ package br.com.academiadev.suicidesquad.mapper;
 
 import br.com.academiadev.suicidesquad.dto.UsuarioCreateDTO;
 import br.com.academiadev.suicidesquad.dto.UsuarioDTO;
+import br.com.academiadev.suicidesquad.dto.UsuarioEditDTO;
 import br.com.academiadev.suicidesquad.entity.Usuario;
 import br.com.academiadev.suicidesquad.service.PasswordService;
 import org.mapstruct.*;
@@ -11,7 +12,7 @@ import java.util.List;
 @Mapper(
         componentModel = "spring",
         unmappedTargetPolicy = ReportingPolicy.IGNORE,
-        uses = {LocalizacaoMapper.class}
+        uses = {LocalizacaoMapper.class, TelefoneMapper.class}
 )
 public abstract class UsuarioMapper {
     @Mappings({
@@ -24,7 +25,16 @@ public abstract class UsuarioMapper {
     })
     public abstract Usuario toEntity(UsuarioCreateDTO dto);
 
-    public abstract List<Usuario> toEntities(List<UsuarioCreateDTO> dtos);
+    @Mappings({
+            @Mapping(target = "nome"),
+            @Mapping(target = "email"),
+            @Mapping(target = "senha", ignore = true),
+            @Mapping(target = "sexo", defaultValue = "NAO_INFORMADO"),
+            @Mapping(target = "dataNascimento", source = "data_nascimento", dateFormat = "yyyy-MM-dd"),
+            @Mapping(target = "localizacao"),
+            @Mapping(target = "telefones")
+    })
+    public abstract Usuario toEntity(UsuarioEditDTO dto);
 
     @Mappings({
             @Mapping(target = "nome"),
@@ -37,5 +47,12 @@ public abstract class UsuarioMapper {
     @AfterMapping
     public void mapearSenha(UsuarioCreateDTO usuarioCreateDTO, @MappingTarget Usuario entity) {
         entity.setSenha(PasswordService.encoder().encode(usuarioCreateDTO.getSenha()));
+    }
+
+    @AfterMapping
+    public void mapearSenha(UsuarioEditDTO usuarioEditDTO, @MappingTarget Usuario entity) {
+        if (usuarioEditDTO.getSenha() != null) {
+            entity.setSenha(PasswordService.encoder().encode(usuarioEditDTO.getSenha()));
+        }
     }
 }

--- a/src/main/java/br/com/academiadev/suicidesquad/repository/LocalizacaoRepository.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/repository/LocalizacaoRepository.java
@@ -1,0 +1,12 @@
+package br.com.academiadev.suicidesquad.repository;
+
+import br.com.academiadev.suicidesquad.entity.Localizacao;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface LocalizacaoRepository extends JpaRepository<Localizacao, Long> {
+    Optional<Localizacao> findByBairroAndCidadeAndUf(String bairro, String cidade, String uf);
+}

--- a/src/main/java/br/com/academiadev/suicidesquad/service/LocalizacaoService.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/service/LocalizacaoService.java
@@ -1,0 +1,26 @@
+package br.com.academiadev.suicidesquad.service;
+
+import br.com.academiadev.suicidesquad.entity.Localizacao;
+import br.com.academiadev.suicidesquad.repository.LocalizacaoRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class LocalizacaoService {
+
+    private final LocalizacaoRepository localizacaoRepository;
+
+    @Autowired
+    public LocalizacaoService(LocalizacaoRepository localizacaoRepository) {
+        this.localizacaoRepository = localizacaoRepository;
+    }
+
+    public Localizacao findOrCreate(String bairro, String cidade, String uf) {
+        return localizacaoRepository.findByBairroAndCidadeAndUf(bairro, cidade, uf)
+                .orElseGet(() -> localizacaoRepository.save(Localizacao.builder()
+                        .bairro(bairro)
+                        .cidade(cidade)
+                        .uf(uf)
+                        .build()));
+    }
+}

--- a/src/main/java/br/com/academiadev/suicidesquad/service/PetService.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/service/PetService.java
@@ -1,15 +1,13 @@
 package br.com.academiadev.suicidesquad.service;
 
-import br.com.academiadev.suicidesquad.entity.Pet;
-import br.com.academiadev.suicidesquad.entity.PetSearch;
-import br.com.academiadev.suicidesquad.entity.QPet;
-import br.com.academiadev.suicidesquad.entity.QRegistro;
+import br.com.academiadev.suicidesquad.entity.*;
 import br.com.academiadev.suicidesquad.enums.Situacao;
 import br.com.academiadev.suicidesquad.repository.PetRepository;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 
 import javax.persistence.EntityManager;
@@ -106,5 +104,11 @@ public class PetService {
 
     public void deleteById(Long idPet) {
         petRepository.deleteById(idPet);
+    }
+
+    public boolean isPublicador(Authentication authentication, Long idPet) {
+        Pet pet = petRepository.findById(idPet).orElse(null);
+        final Usuario usuario = (Usuario) authentication.getPrincipal();
+        return (pet != null) && (usuario != null) && (usuario.getId() != null) && pet.getUsuario().getId().equals(usuario.getId());
     }
 }

--- a/src/main/java/br/com/academiadev/suicidesquad/service/PetService.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/service/PetService.java
@@ -99,4 +99,12 @@ public class PetService {
 
         return petRepository.findAll(builder);
     }
+
+    public boolean existsById(Long idPet) {
+        return petRepository.existsById(idPet);
+    }
+
+    public void deleteById(Long idPet) {
+        petRepository.deleteById(idPet);
+    }
 }

--- a/src/main/java/br/com/academiadev/suicidesquad/service/UsuarioService.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/service/UsuarioService.java
@@ -36,4 +36,12 @@ public class UsuarioService {
         }
         return usuarioRepository.findByFacebookUserId(facebookUserId);
     }
+
+    public boolean existsById(Long idUsuario) {
+        return usuarioRepository.existsById(idUsuario);
+    }
+
+    public void deleteById(Long idUsuario) {
+        usuarioRepository.deleteById(idUsuario);
+    }
 }

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,22 +1,102 @@
-INSERT INTO localizacao (bairro, cidade, uf) VALUES
-  ('Centro', 'São Francisco do Sul', 'SC'),
-  ('Floresta', 'Joinville', 'SC');
+INSERT INTO LOCALIZACAO (BAIRRO, CIDADE, UF) VALUES
+('Jardim São Jorge', 'Londrina', 'Paraná'),
+('Vila Olinda', 'Rondonópolis', 'Mato Grosso'),
+('Parque Dois Irmãos', 'Fortaleza', 'Ceará'),
+('Cafezinho', 'Ji-Paraná', 'Rondônia'),
+('Seis de Agosto', 'Rio Branco', 'Acre'),
+('Serrinha', 'Fortaleza', 'Ceará'),
+('Monte Verde', 'Florianópolis', 'Santa Catarina'),
+('Santa Maria', 'Aracaju', 'Sergipe');
 
-INSERT INTO pet (
-  nome, comprimento_pelo, id_localizacao, porte, raca, tipo, sexo, categoria, vacinacao, castracao
-) VALUES
-  ('Fred', 1, 1, 1, 1, 1, 1, 1, 1, 1),
-  ('Paçoca', 2, 2, 2, 2, 2, 2, 2, 2, 2),
-  ('Foca', 3, 1, 3, 6, 3, 3, 3, 3, 3);
+INSERT INTO USUARIO (CREATED_DATE, LAST_MODIFIED_DATE, DATA_NASCIMENTO, EMAIL, FACEBOOK_USER_ID, NOME, SENHA, SEXO, LOCALIZACAO_ID) VALUES
+('2018-11-23 13:18:25', '2018-11-24 17:24:53', '1970-12-10', 'dchristophle0@example.com', null, 'Danny Christophle', '$2a$10$YIqp1w.m/4brTM9vfXyuc.qCB/e4UkF8WMUh9b2ySspSXzCZMlZLS', 1, 1),
+('2018-11-18 03:33:23', '2018-11-18 06:33:23', '1988-10-12', 'gnusche1@example.com', null, 'Gualterio Nusche', '$2a$10$2tTVuJQAyEhyy77MHniEGOEyJQave6ezht17Q8AOU5QPZqvtoul5e', 1, 2),
+('2018-11-26 05:31:25', '2018-11-26 14:58:10', null, 'dwortt2@example.com', null, 'Dennie Wortt', '$2a$10$bC0R9ksjYhd//5m10ciPluxpjOUT75bYa6ya/rZ1qiARaZGB.yinC', 3, 3),
+('2018-10-13 06:12:17', '2018-11-16 06:44:07', '2008-11-05', 'sconnal3@example.com', null, 'Salomi Connal', '$2a$10$V4ej2VaXtDLgEM0dQ6Va3ucibkJ07T38.rcZ/Iz61c48MgRm0ODv6', 2, 4),
+('2018-09-10 17:24:53', '2018-11-20 14:04:17', '2010-05-21', 'dpfleger4@example.com', null, 'Dulce Pfleger', '$2a$10$EK7Wd/5kTniJ0wFl01zkVuAU.Ja5yu9LvCd9/8SCwsG.5mr4Li2ou', 3, 5),
+('2018-11-10 14:58:33', '2018-11-25 14:26:17', '1985-05-02', 'loakwood5@example.com', null, 'Lela Oakwood', '$2a$10$7zn19kqTV09C0e8shv8wBOmCrFQ2GMPyItBvvjniW3O8Enf30yING', 3, 6),
+('2018-09-18 08:59:56', '2018-11-18 17:12:06', null, 'kjoye6@example.com', null, 'Kitti Joye', '$2a$10$NIv/3CWCh4t7RzEgbFeWT./hIEgFQEtmHKgz5YyXQKK0ezIpRwh9K', 3, 7),
+('2018-10-16 17:04:14', '2018-11-16 19:37:22', '1995-12-29', 'egalliver7@example.com', null, 'Euphemia Galliver', '$2a$10$K33sDIo6WQ6gjWMwJddzL.xnmTHudr5.ckpG5Z29.80wLSJ7bJWim', 2, 8),
+('2018-11-17 22:37:19', '2018-11-17 23:33:03', null, 'okira0@example.com', null, 'Onfroi Kira', '$2a$10$lI8FFVHeiVyCBEV3dQCmSOrHAOsJRYTDC23rcSVNDh3usclJCk54S', 3, null),
+('2018-11-14 08:03:55', '2018-11-14 22:18:13', '2018-03-09', 'nhathwood1@example.com', null, 'Nicolle Hathwood', '$2a$10$Qm003NFCbAfG8B0sn.Y1luc3VbDtTCF/ktolGkYw3d.kNDZ5/y106', 1, null);
 
-INSERT INTO registro (id_pet, situacao, data) VALUES
-  (1, 1, '2018-01-01T01:00:00'),
-  (1, 2, '2018-02-01T02:00:00'),
-  (1, 3, '2018-03-01T03:00:00'),
-  (1, 2, '2018-02-03T02:00:00'),
-  (1, 3, '2018-02-03T03:00:00');
+INSERT INTO PUBLIC.TELEFONE (NUMERO, IS_WHATSAPP, USUARIO_ID) VALUES
+('(16) 92289-2031', false, 9),
+('(19) 98809-1455', true, 6),
+('(56) 95060-5313', false, 9),
+('(42) 95372-5735', false, 6),
+('(47) 96989-9372', false, 8),
+('(65) 95242-2496', true, 7),
+('(81) 95777-3154', false, 1),
+('(07) 98649-8202', false, 3),
+('(09) 94314-8080', false, 1),
+('(07) 90680-6466', false, 6),
+('(06) 98014-9824', false, 9),
+('(71) 96478-3863', false, 8),
+('(89) 92399-8864', false, 7),
+('(00) 93304-3338', false, 2),
+('(91) 97019-7068', false, 1),
+('(04) 91985-1627', true, 1),
+('(69) 91676-4020', true, 10),
+('(25) 99643-1119', false, 4),
+('(30) 91833-1602', false, 10),
+('(74) 96177-0719', false, 10),
+('(07) 94580-1775', false, 2),
+('(61) 91223-1970', false, 1),
+('(90) 99053-4818', false, 2),
+('(16) 91185-9877', false, 3),
+('(54) 97647-3597', true, 10),
+('(38) 98090-9231', false, 2),
+('(75) 97837-0110', false, 10),
+('(87) 92225-9566', false, 4),
+('(74) 97368-6463', false, 4),
+('(36) 98710-8248', false, 8),
+('(69) 95786-1364', true, 7),
+('(17) 93059-8685', false, 5),
+('(80) 99955-9718', false, 3),
+('(21) 91990-4222', false, 4),
+('(84) 98945-3989', true, 7),
+('(66) 95651-5080', false, 3),
+('(64) 95515-5092', true, 3),
+('(26) 94608-2857', false, 5),
+('(18) 99920-1902', true, 9),
+('(99) 96356-1420', true, 10),
+('(02) 96517-7477', false, 6),
+('(50) 92794-1789', false, 10);
 
-INSERT INTO pet_cor (PET_ID, CORES) VALUES
-  (1, 1),
-  (1, 2),
-  (1, 3);
+
+INSERT INTO PET (CREATED_DATE, LAST_MODIFIED_DATE, CASTRACAO, CATEGORIA, COMPRIMENTO_PELO, DESCRICAO, NOME, PORTE, RACA, SEXO, TIPO, VACINACAO, ID_LOCALIZACAO, USUARIO_ID) VALUES
+('2018-11-25 18:58:41', '2018-11-26 01:54:33', 1, 3, 4, 'Vivamus in felis eu sapien cursus vestibulum.', 'Arabelle', 1, 5, 3, 1, 1, null, 10),
+('2018-11-24 18:09:41', '2018-11-24 18:35:46', 1, 2, 1, 'Curabitur convallis. Duis consequat dui nec nisi volutpat eleifend.', 'Wolfy', 3, 4, 3, 1, 1, null, 10),
+('2018-11-24 02:45:47', '2018-11-24 18:07:05', 1, 3, 2, 'Fusce consequat. Nulla nisl. Nunc nisl.', 'Creighton', 1, 4, 3, 1, 1, 4, 10),
+('2018-11-23 06:49:59', '2018-11-24 08:11:06', 1, 2, 1, 'Proin eu mi. Nulla ac enim. In tempor, turpis nec euismod scelerisque, quam turpis adipiscing lorem, vitae mattis nibh ligula nec sem.', null, 2, 5, 3, 1, 1, null, 9),
+('2018-11-23 20:33:38', '2018-11-24 02:38:02', 1, 3, 3, null, null, 2, 4, 3, 1, 1, null, 2),
+('2018-11-23 19:24:58', '2018-11-24 05:52:45', 1, 3, 1, 'Vestibulum rutrum rutrum neque. Aenean auctor gravida sem. Praesent id massa id nisl venenatis lacinia.', 'Isidro', 3, 7, 3, 2, 1, null, 5),
+('2018-11-23 03:47:14', '2018-11-23 21:31:59', 1, 1, 1, 'Pellentesque viverra pede ac diam.', 'Julee', 1, 6, 3, 2, 1, null, 9),
+('2018-11-23 20:08:20', '2018-11-24 03:06:22', 1, 2, 3, 'Morbi sem mauris, laoreet ut, rhoncus aliquet, pulvinar sed, nisl.', 'Merridie', 1, 7, 3, 2, 1, 3, 8),
+('2018-11-26 13:23:29', '2018-11-26 13:49:13', 1, 3, 4, null, 'Itch', 3, 7, 3, 2, 1, 2, 9),
+('2018-11-23 01:04:15', '2018-11-23 11:53:37', 1, 1, 2, 'Phasellus sit amet erat. Nulla tempus. Vivamus in felis eu sapien cursus vestibulum.', null, 1, 8, 3, 3, 1, null, 4),
+('2018-11-26 12:37:41', '2018-11-27 06:58:54', 1, 2, 4, 'Ut at dolor quis odio consequat varius.', 'Julee', 3, 9, 3, 3, 1, null, 2);
+
+INSERT INTO REGISTRO (ID_PET, DATA, SITUACAO) VALUES
+(1, '2018-12-05 21:26:12', 1),
+(1, '2018-12-06 16:17:45', 2),
+(1, '2018-12-12 08:38:15', 3),
+(9, '2018-12-06 05:08:41', 1),
+(9, '2018-12-06 19:14:12', 2),
+(9, '2018-12-10 16:21:59', 3),
+(10, '2018-12-07 13:51:43', 1),
+(10, '2018-12-08 13:44:54', 2),
+(10, '2018-12-12 22:08:31', 3),
+(7, '2018-12-10 18:29:26', 1),
+(7, '2018-12-11 05:33:40', 2),
+(7, '2018-12-16 09:30:47', 3),
+(6, '2018-11-30 10:04:11', 1),
+(6, '2018-12-01 12:56:46', 2),
+(8, '2018-12-03 11:05:50', 1),
+(8, '2018-12-04 11:10:45', 2),
+(5, '2018-11-30 00:30:53', 1),
+(5, '2018-11-30 22:09:43', 2),
+(2, '2018-12-10 22:59:51', 1),
+(3, '2018-12-02 23:32:35', 1),
+(4, '2018-12-08 03:35:50', 1);

--- a/src/test/java/br/com/academiadev/suicidesquad/controller/PetControllerTest.java
+++ b/src/test/java/br/com/academiadev/suicidesquad/controller/PetControllerTest.java
@@ -51,13 +51,15 @@ public class PetControllerTest {
     private JwtTokenProvider jwtTokenProvider;
 
     private Pet buildPet() {
+        Set<Cor> cores = new HashSet<>();
+        cores.add(Cor.PRETO);
+        cores.add(Cor.BRANCO);
         return Pet.builder()
                 .tipo(Tipo.GATO)
                 .porte(Porte.MEDIO)
                 .comprimentoPelo(ComprimentoPelo.MEDIO)
                 .categoria(Categoria.ACHADO)
-                .cor(Cor.BRANCO)
-                .cor(Cor.PRETO)
+                .cores(cores)
                 .build();
     }
 
@@ -111,14 +113,19 @@ public class PetControllerTest {
     @Test
     public void buscarPets_quandoEncontra_entaoRetorna() throws Exception {
         List<Pet> pets = new ArrayList<>();
+        Set<Cor> coresA = new HashSet<>();
+        coresA.add(Cor.BRANCO);
+        coresA.add(Cor.MARROM);
+        coresA.add(Cor.PRETO);
+        Set<Cor> coresB = new HashSet<>();
+        coresB.add(Cor.BRANCO);
+        coresB.add(Cor.MARROM);
         pets.add(Pet.builder()
                 .tipo(Tipo.CACHORRO)
                 .porte(Porte.PEQUENO)
                 .comprimentoPelo(ComprimentoPelo.SEM_PELO)
                 .categoria(Categoria.PERDIDO)
-                .cor(Cor.BRANCO)
-                .cor(Cor.MARROM)
-                .cor(Cor.PRETO)
+                .cores(coresA)
                 .build());
         pets.add(Pet.builder()
                 .tipo(Tipo.CACHORRO)
@@ -126,8 +133,7 @@ public class PetControllerTest {
                 .comprimentoPelo(ComprimentoPelo.SEM_PELO)
                 .categoria(Categoria.PERDIDO)
                 .raca(Raca.PITBULL)
-                .cor(Cor.BRANCO)
-                .cor(Cor.MARROM)
+                .cores(coresB)
                 .build());
         pets.add(Pet.builder()
                 .tipo(Tipo.GATO)

--- a/src/test/java/br/com/academiadev/suicidesquad/mapper/PetMapperTest.java
+++ b/src/test/java/br/com/academiadev/suicidesquad/mapper/PetMapperTest.java
@@ -1,0 +1,134 @@
+package br.com.academiadev.suicidesquad.mapper;
+
+import br.com.academiadev.suicidesquad.dto.LocalizacaoDTO;
+import br.com.academiadev.suicidesquad.dto.PetCreateDTO;
+import br.com.academiadev.suicidesquad.entity.Localizacao;
+import br.com.academiadev.suicidesquad.entity.Pet;
+import br.com.academiadev.suicidesquad.entity.Usuario;
+import br.com.academiadev.suicidesquad.enums.Categoria;
+import br.com.academiadev.suicidesquad.enums.ComprimentoPelo;
+import br.com.academiadev.suicidesquad.enums.Porte;
+import br.com.academiadev.suicidesquad.enums.Tipo;
+import br.com.academiadev.suicidesquad.repository.LocalizacaoRepository;
+import br.com.academiadev.suicidesquad.service.PetService;
+import br.com.academiadev.suicidesquad.service.UsuarioService;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@Transactional
+public class PetMapperTest {
+    @Autowired
+    private PetMapper petMapper;
+
+    @Autowired
+    private PetService petService;
+
+    @Autowired
+    private UsuarioService usuarioService;
+
+    @Autowired
+    private LocalizacaoRepository localizacaoRepository;
+
+    private Usuario buildUsuario() {
+        return Usuario.builder()
+                .nome("Exemplo")
+                .email("exemplo@example.com")
+                .senha("hunter2")
+                .build();
+    }
+
+    @Test
+    public void editarPet_quandoNovaLocalizacao_entaoCriarNovaLocalizacao() {
+        final Usuario usuario = usuarioService.save(buildUsuario());
+
+        Localizacao localizacaoA = localizacaoRepository.save(new Localizacao(
+                "Centro",
+                "São Francisco do Sul",
+                "Santa Catarina"));
+        Pet petA = petService.save(Pet.builder()
+                .tipo(Tipo.GATO)
+                .porte(Porte.MEDIO)
+                .comprimentoPelo(ComprimentoPelo.MEDIO)
+                .categoria(Categoria.ACHADO)
+                .usuario(usuario)
+                .localizacao(localizacaoA)
+                .build());
+        Pet petB = petService.save(Pet.builder()
+                .tipo(Tipo.CACHORRO)
+                .porte(Porte.MEDIO)
+                .comprimentoPelo(ComprimentoPelo.CURTO)
+                .categoria(Categoria.ACHADO)
+                .usuario(usuario)
+                .build());
+
+        PetCreateDTO petB_EditDTO = new PetCreateDTO();
+        petB_EditDTO.setTipo(petB.getTipo().toString());
+        petB_EditDTO.setPorte(petB.getPorte().toString());
+        petB_EditDTO.setComprimento_pelo(petB.getComprimentoPelo().toString());
+        petB_EditDTO.setCategoria(petB.getCategoria().toString());
+
+        LocalizacaoDTO localizacaoB_DTO = new LocalizacaoDTO();
+        localizacaoB_DTO.setBairro("Floresta");
+        localizacaoB_DTO.setCidade("Joinville");
+        localizacaoB_DTO.setUf("Santa Catarina");
+        petB_EditDTO.setLocalizacao(localizacaoB_DTO);
+
+        petMapper.updateEntity(petB_EditDTO, petB);
+
+        assertThat(petB.getTipo(), equalTo(Tipo.CACHORRO));
+        assertThat(petB.getLocalizacao().getId(), not(localizacaoA.getId()));
+        assertThat(localizacaoRepository.findAll(), hasSize(2));
+    }
+
+    @Test
+    public void editarPet_quandoLocalizacaoExistente_entaoUsaLocalizacaoExistente() {
+        final Usuario usuario = usuarioService.save(buildUsuario());
+
+        Localizacao localizacaoA = localizacaoRepository.save(new Localizacao(
+                "Centro",
+                "São Francisco do Sul",
+                "Santa Catarina"));
+        Pet petA = petService.save(Pet.builder()
+                .tipo(Tipo.GATO)
+                .porte(Porte.MEDIO)
+                .comprimentoPelo(ComprimentoPelo.MEDIO)
+                .categoria(Categoria.ACHADO)
+                .usuario(usuario)
+                .localizacao(localizacaoA)
+                .build());
+        Pet petB = petService.save(Pet.builder()
+                .tipo(Tipo.CACHORRO)
+                .porte(Porte.MEDIO)
+                .comprimentoPelo(ComprimentoPelo.CURTO)
+                .categoria(Categoria.ACHADO)
+                .usuario(usuario)
+                .build());
+
+        PetCreateDTO petB_EditDTO = new PetCreateDTO();
+        petB_EditDTO.setTipo(petB.getTipo().toString());
+        petB_EditDTO.setPorte(petB.getPorte().toString());
+        petB_EditDTO.setComprimento_pelo(petB.getComprimentoPelo().toString());
+        petB_EditDTO.setCategoria(petB.getCategoria().toString());
+
+        LocalizacaoDTO localizacaoA_DTO = new LocalizacaoDTO();
+        localizacaoA_DTO.setBairro(localizacaoA.getBairro());
+        localizacaoA_DTO.setCidade(localizacaoA.getCidade());
+        localizacaoA_DTO.setUf(localizacaoA.getUf());
+        petB_EditDTO.setLocalizacao(localizacaoA_DTO);
+
+        petMapper.updateEntity(petB_EditDTO, petB);
+
+        assertThat(petB.getTipo(), equalTo(Tipo.CACHORRO));
+        assertThat(petB.getLocalizacao().getId(), equalTo(localizacaoA.getId()));
+        assertThat(localizacaoRepository.findAll(), hasSize(1));
+    }
+}

--- a/src/test/java/br/com/academiadev/suicidesquad/mapper/UsuarioMapperTest.java
+++ b/src/test/java/br/com/academiadev/suicidesquad/mapper/UsuarioMapperTest.java
@@ -1,0 +1,92 @@
+package br.com.academiadev.suicidesquad.mapper;
+
+import br.com.academiadev.suicidesquad.dto.LocalizacaoDTO;
+import br.com.academiadev.suicidesquad.dto.UsuarioEditDTO;
+import br.com.academiadev.suicidesquad.entity.Localizacao;
+import br.com.academiadev.suicidesquad.entity.Usuario;
+import br.com.academiadev.suicidesquad.repository.LocalizacaoRepository;
+import br.com.academiadev.suicidesquad.service.UsuarioService;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@Transactional
+public class UsuarioMapperTest {
+    @Autowired
+    private UsuarioMapper usuarioMapper;
+
+    @Autowired
+    private UsuarioService usuarioService;
+
+    @Autowired
+    private LocalizacaoRepository localizacaoRepository;
+
+    private Localizacao buildLocalizacao() {
+        return new Localizacao(
+                "Centro",
+                "São Francisco do Sul",
+                "Santa Catarina");
+    }
+
+    private Usuario buildUsuario(String desc, Localizacao localizacao) {
+        return Usuario.builder()
+                .nome(String.format("Usuário %s", desc))
+                .email(String.format("usuario.%s@example.com", desc))
+                .localizacao(localizacao)
+                .build();
+    }
+
+    @Test
+    public void editarUsuario_quandoNovaLocalizacao_entaoCriarNovaLocalizacao() {
+        Localizacao localizacaoA  = localizacaoRepository.save(buildLocalizacao());
+        Usuario usuarioA = usuarioService.save(buildUsuario("A", localizacaoA));
+        Usuario usuarioB = usuarioService.save(buildUsuario("B", null));
+
+        UsuarioEditDTO usuarioB_EditDTO = new UsuarioEditDTO();
+        usuarioB_EditDTO.setNome(usuarioB.getNome());
+        usuarioB_EditDTO.setEmail(usuarioB.getEmail());
+
+        LocalizacaoDTO localizacaoB_DTO = new LocalizacaoDTO();
+        localizacaoB_DTO.setBairro("Floresta");
+        localizacaoB_DTO.setCidade("Joinville");
+        localizacaoB_DTO.setUf("Santa Catarina");
+        usuarioB_EditDTO.setLocalizacao(localizacaoB_DTO);
+
+        usuarioMapper.updateEntity(usuarioB_EditDTO, usuarioB);
+
+        assertThat(usuarioB.getNome(), equalTo("Usuário B"));
+        assertThat(usuarioB.getLocalizacao().getId(), not(localizacaoA.getId()));
+        assertThat(localizacaoRepository.findAll(), hasSize(2));
+    }
+
+    @Test
+    public void editarUsuario_quandoLocalizacaoExistente_entaoUsaLocalizacaoExistente() {
+        Localizacao localizacaoA  = localizacaoRepository.save(buildLocalizacao());
+        Usuario usuarioA = usuarioService.save(buildUsuario("A", localizacaoA));
+        Usuario usuarioB = usuarioService.save(buildUsuario("B", null));
+
+        UsuarioEditDTO usuarioB_EditDTO = new UsuarioEditDTO();
+        usuarioB_EditDTO.setNome(usuarioB.getNome());
+        usuarioB_EditDTO.setEmail(usuarioB.getEmail());
+
+        LocalizacaoDTO localizacaoA_DTO = new LocalizacaoDTO();
+        localizacaoA_DTO.setBairro(localizacaoA.getBairro());
+        localizacaoA_DTO.setCidade(localizacaoA.getCidade());
+        localizacaoA_DTO.setUf(localizacaoA.getUf());
+        usuarioB_EditDTO.setLocalizacao(localizacaoA_DTO);
+
+        usuarioMapper.updateEntity(usuarioB_EditDTO, usuarioB);
+
+        assertThat(usuarioB.getNome(), equalTo("Usuário B"));
+        assertThat(usuarioB.getLocalizacao().getId(), equalTo(localizacaoA.getId()));
+        assertThat(localizacaoRepository.findAll(), hasSize(1));
+    }
+}


### PR DESCRIPTION
Closes #44, closes #45, closes #46.

# O que foi feito

* Revistas as relações entre usuário e telefone, e pets e registros.
* Eliminado o uso da anotação `@Singular`, que gerava listas imutáveis, inviabilizando o uso do MapStruct para editar um usuário existente.
* Definido um `UsuarioEditDTO`, que difere do `UsuarioCreateDTO` por não requerir uma senha, e aceitar uma lista de telefones.
* Definido o `TelefoneDTO` e o `RegistroCreateDTO`, para o uso na edição do usuário e do pet.
* Alterado o `UsuarioCreateDTO` para requerir e-mails válidos (`@Email`).
* Adicionados métodos ao `UsuarioMapper` e `PetMapper` para atualizar instâncias existentes de seus modelos.
* Adicionados repositório, serviço, DTO, e mapper para localização.
* Adicionados endpoints para a edição de pets e usuários, usando os DTOs e os mappers definidos.
* Adicionado endpoints para a adição de registro de situação ao pet.
* Adicionados testes de integração para a edição.

# Por que foi feito

Para que o usuário possa alterar informações de seus itens após cadastrados.
