### PR TITLE
Adicionar src/main/generated como caminho de sources

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,6 +76,7 @@ querydsl {
 
 sourceSets {
 	main.java.srcDirs += 'build/generated/source/apt/main'
+	main.java.srcDirs += 'src/main/generated'
 }
 
 // Herdar configurações do Gradle


### PR DESCRIPTION
# O que foi feito

* Adicionado o caminho ```src/main/generated``` ao ```main.java.srcDirs``` no ```build.gradle```.

# Por que foi feito

Para fazer o IntelliJ 2018.3 reconhecer os arquivos gerados pelo Querydsl (```QPet```, etc.).