### PR TITLE
Adicionar exceções e handler de exceções

### DIFF
--- a/src/main/java/br/com/academiadev/suicidesquad/config/SecurityConfig.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package br.com.academiadev.suicidesquad.config;
 
 import br.com.academiadev.suicidesquad.security.JwtTokenProvider;
+import br.com.academiadev.suicidesquad.security.RestAuthenticationEntryPoint;
 import br.com.academiadev.suicidesquad.service.CustomUserDetailsService;
 import br.com.academiadev.suicidesquad.service.PasswordService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,6 +25,9 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
     @Autowired
     private CustomUserDetailsService userDetailsService;
+
+    @Autowired
+    private RestAuthenticationEntryPoint restAuthenticationEntryPoint;
 
     @Bean
     @Override
@@ -70,6 +74,9 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 ).permitAll()
                 .anyRequest().authenticated()
                 .and()
+            .exceptionHandling()
+                .authenticationEntryPoint(restAuthenticationEntryPoint)
+                .and()
             .apply(new JwtConfigurer(jwtTokenProvider));
         // @formatter:on
     }
@@ -78,5 +85,4 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     protected void configure(AuthenticationManagerBuilder auth) throws Exception {
         auth.userDetailsService(userDetailsService).passwordEncoder(PasswordService.encoder());
     }
-
 }

--- a/src/main/java/br/com/academiadev/suicidesquad/controller/PetController.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/controller/PetController.java
@@ -6,9 +6,8 @@ import br.com.academiadev.suicidesquad.dto.PetDetailDTO;
 import br.com.academiadev.suicidesquad.dto.RegistroCreateDTO;
 import br.com.academiadev.suicidesquad.entity.Pet;
 import br.com.academiadev.suicidesquad.entity.PetSearch;
-import br.com.academiadev.suicidesquad.entity.Registro;
 import br.com.academiadev.suicidesquad.entity.Usuario;
-import br.com.academiadev.suicidesquad.exception.ResourceNotFoundException;
+import br.com.academiadev.suicidesquad.exception.PetNotFoundException;
 import br.com.academiadev.suicidesquad.mapper.PetMapper;
 import br.com.academiadev.suicidesquad.mapper.RegistroMapper;
 import br.com.academiadev.suicidesquad.service.PetService;
@@ -56,7 +55,7 @@ public class PetController {
         return petService
                 .findById(idPet)
                 .map(petMapper::toDetailDto)
-                .orElseThrow(() -> new ResourceNotFoundException("Pet com o id " + idPet + " não foi encontrado"));
+                .orElseThrow(PetNotFoundException::new);
     }
 
     @DeleteMapping("/pets/{idPet}")

--- a/src/main/java/br/com/academiadev/suicidesquad/controller/UsuarioController.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/controller/UsuarioController.java
@@ -4,13 +4,13 @@ import br.com.academiadev.suicidesquad.dto.UsuarioCreateDTO;
 import br.com.academiadev.suicidesquad.dto.UsuarioDTO;
 import br.com.academiadev.suicidesquad.dto.UsuarioEditDTO;
 import br.com.academiadev.suicidesquad.entity.Usuario;
+import br.com.academiadev.suicidesquad.exception.UsuarioNotFoundException;
 import br.com.academiadev.suicidesquad.mapper.UsuarioMapper;
 import br.com.academiadev.suicidesquad.service.UsuarioService;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.rest.webmvc.ResourceNotFoundException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -42,7 +42,7 @@ public class UsuarioController {
     public UsuarioDTO getUsuarioById(@PathVariable Long idUsuario) {
         return usuarioService.findById(idUsuario)
                 .map(usuarioMapper::toDto)
-                .orElseThrow(() -> new ResourceNotFoundException("Usuário com o id" + idUsuario + " não foi encontrado"));
+                .orElseThrow(UsuarioNotFoundException::new);
     }
 
     @ApiOperation(value = "Cria o usuário")

--- a/src/main/java/br/com/academiadev/suicidesquad/exception/APIException.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/exception/APIException.java
@@ -1,0 +1,4 @@
+package br.com.academiadev.suicidesquad.exception;
+
+public abstract class APIException extends RuntimeException {
+}

--- a/src/main/java/br/com/academiadev/suicidesquad/exception/PetNotFoundException.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/exception/PetNotFoundException.java
@@ -1,0 +1,9 @@
+package br.com.academiadev.suicidesquad.exception;
+
+public class PetNotFoundException extends ResourceNotFoundException {
+
+    @Override
+    public String getMessage() {
+        return "Pet não encontrado";
+    }
+}

--- a/src/main/java/br/com/academiadev/suicidesquad/exception/ResourceNotFoundException.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/exception/ResourceNotFoundException.java
@@ -1,15 +1,5 @@
 package br.com.academiadev.suicidesquad.exception;
 
-import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.ResponseStatus;
-
-@ResponseStatus(HttpStatus.NOT_FOUND)
-public class ResourceNotFoundException extends RuntimeException {
-    public ResourceNotFoundException(String message) {
-        super(message);
-    }
-
-    public ResourceNotFoundException(String message, Throwable cause) {
-        super(message, cause);
-    }
+public abstract class ResourceNotFoundException extends APIException {
+    public abstract String getMessage();
 }

--- a/src/main/java/br/com/academiadev/suicidesquad/exception/UsuarioNotFoundException.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/exception/UsuarioNotFoundException.java
@@ -1,0 +1,9 @@
+package br.com.academiadev.suicidesquad.exception;
+
+public class UsuarioNotFoundException extends ResourceNotFoundException {
+
+    @Override
+    public String getMessage() {
+        return "Usuário não encontrado";
+    }
+}

--- a/src/main/java/br/com/academiadev/suicidesquad/exception/handler/RestResponseEntityExceptionHandler.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/exception/handler/RestResponseEntityExceptionHandler.java
@@ -62,18 +62,16 @@ public class RestResponseEntityExceptionHandler extends ResponseEntityExceptionH
     protected ResponseEntity<Object> handleMethodArgumentNotValid(@Nonnull MethodArgumentNotValidException e, @Nonnull HttpHeaders headers, @Nonnull HttpStatus status, @Nonnull WebRequest request) {
         List<ObjectNode> fieldErrorNodes = e.getBindingResult().getAllErrors().stream()
                 .map(objectError -> {
+                    final ObjectNode fieldErrorNode = objectMapper.createObjectNode();
                     if (objectError instanceof FieldError) {
-                        final ObjectNode fieldErrorNode = objectMapper.createObjectNode();
                         fieldErrorNode.put("field", ((FieldError) objectError).getField());
                         final Object rejectedValue = ((FieldError) objectError).getRejectedValue();
                         fieldErrorNode.put("value", rejectedValue == null ? null : rejectedValue.toString());
                         fieldErrorNode.put("error", objectError.getDefaultMessage());
-                        return fieldErrorNode;
                     } else {
-                        final ObjectNode objectErrorNode = objectMapper.createObjectNode();
-                        objectErrorNode.put("error", objectError.toString());
-                        return objectErrorNode;
+                        fieldErrorNode.put("error", objectError.toString());
                     }
+                    return fieldErrorNode;
                 })
                 .collect(Collectors.toList());
 

--- a/src/main/java/br/com/academiadev/suicidesquad/exception/handler/RestResponseEntityExceptionHandler.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/exception/handler/RestResponseEntityExceptionHandler.java
@@ -1,0 +1,119 @@
+package br.com.academiadev.suicidesquad.exception.handler;
+
+import br.com.academiadev.suicidesquad.exception.ResourceNotFoundException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import javax.annotation.Nonnull;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@ControllerAdvice
+public class RestResponseEntityExceptionHandler extends ResponseEntityExceptionHandler {
+    private final ObjectMapper objectMapper;
+
+    @Autowired
+    public RestResponseEntityExceptionHandler(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @ExceptionHandler({
+            Exception.class
+    })
+    public ResponseEntity<Object> handleAllExceptions(Exception e, WebRequest request) throws JsonProcessingException {
+        final ObjectNode errorNode = objectMapper.createObjectNode();
+        errorNode.put("code", 500);
+        errorNode.put("error", "Internal server error");
+        final HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON_UTF8);
+        e.printStackTrace();
+        return handleExceptionInternal(e, objectMapper.writeValueAsString(errorNode), headers, HttpStatus.INTERNAL_SERVER_ERROR, request);
+    }
+
+    @ExceptionHandler({
+            ResourceNotFoundException.class
+    })
+    protected ResponseEntity<Object> handleResouceNotFound(ResourceNotFoundException e, WebRequest request) throws JsonProcessingException {
+        final ObjectNode errorNode = objectMapper.createObjectNode();
+        errorNode.put("code", 404);
+        errorNode.put("error", e.getMessage());
+        final HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON_UTF8);
+        return handleExceptionInternal(e, objectMapper.writeValueAsString(errorNode), headers, HttpStatus.NOT_FOUND, request);
+    }
+
+    @Override
+    @Nonnull
+    protected ResponseEntity<Object> handleMethodArgumentNotValid(@Nonnull MethodArgumentNotValidException e, @Nonnull HttpHeaders headers, @Nonnull HttpStatus status, @Nonnull WebRequest request) {
+        List<ObjectNode> fieldErrorNodes = e.getBindingResult().getAllErrors().stream()
+                .map(objectError -> {
+                    if (objectError instanceof FieldError) {
+                        final ObjectNode fieldErrorNode = objectMapper.createObjectNode();
+                        fieldErrorNode.put("field", ((FieldError) objectError).getField());
+                        final Object rejectedValue = ((FieldError) objectError).getRejectedValue();
+                        fieldErrorNode.put("value", rejectedValue == null ? null : rejectedValue.toString());
+                        fieldErrorNode.put("error", objectError.getDefaultMessage());
+                        return fieldErrorNode;
+                    } else {
+                        final ObjectNode objectErrorNode = objectMapper.createObjectNode();
+                        objectErrorNode.put("error", objectError.toString());
+                        return objectErrorNode;
+                    }
+                })
+                .collect(Collectors.toList());
+
+        final ObjectNode errorNode = objectMapper.createObjectNode();
+        errorNode.put("code", 400);
+        errorNode.put("error", "Campos inválidos");
+        errorNode.putArray("field_errors").addAll(fieldErrorNodes);
+
+        String body = null;
+        try {
+            body = objectMapper.writeValueAsString(errorNode);
+        } catch (JsonProcessingException e1) {
+            e1.printStackTrace();
+        }
+        headers.setContentType(MediaType.APPLICATION_JSON_UTF8);
+        return handleExceptionInternal(e, body, headers, HttpStatus.BAD_REQUEST, request);
+    }
+
+    @ExceptionHandler({
+            BadCredentialsException.class
+    })
+    protected ResponseEntity<Object> handleBadCredentials(BadCredentialsException e, WebRequest request) throws JsonProcessingException {
+        ObjectNode errorNode = objectMapper.createObjectNode();
+        errorNode.put("code", 401);
+        errorNode.put("error", "Email ou senha inválidos");
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON_UTF8);
+        return handleExceptionInternal(e, objectMapper.writeValueAsString(errorNode), headers, HttpStatus.UNAUTHORIZED, request);
+    }
+
+    @ExceptionHandler({
+            AccessDeniedException.class,
+            AuthenticationException.class
+    })
+    protected ResponseEntity<Object> handleAuthenticationException(RuntimeException e, WebRequest request) throws JsonProcessingException {
+        ObjectNode errorNode = objectMapper.createObjectNode();
+        errorNode.put("code", 403);
+        errorNode.put("error", "Não autorizado");
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON_UTF8);
+        return handleExceptionInternal(e, objectMapper.writeValueAsString(errorNode), headers, HttpStatus.FORBIDDEN, request);
+    }
+}

--- a/src/main/java/br/com/academiadev/suicidesquad/security/RestAuthenticationEntryPoint.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/security/RestAuthenticationEntryPoint.java
@@ -1,0 +1,26 @@
+package br.com.academiadev.suicidesquad.security;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerExceptionResolver;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@Component
+public class RestAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    private final HandlerExceptionResolver resolver;
+
+    @Autowired
+    public RestAuthenticationEntryPoint(@Qualifier("handlerExceptionResolver") HandlerExceptionResolver resolver) {
+        this.resolver = resolver;
+    }
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) {
+        resolver.resolveException(request, response, null, authException);
+    }
+}


### PR DESCRIPTION
Closes #72.

# O que foi feito

* Adicionado  `@ControllerAdvice RestResponseEntityExceptionHandler` que define como as exceções são tratadas.
* Adicionados _handlers_:
    * `handleMethodArgumentNotValid` Campos inválidos submetidos. _400 Bad Request_
    * `handleBadCredentials` Usuário/senha inválidos no login. _401 Unauthorized_
    * `handleAuthenticationException` Token inválido ou usuário sem permissão para o acesso. _403 Forbidden_
    * `handleResouceNotFound` Recurso não existe. _404 Not Found_
    * `handleAllExceptions` Genérico. _500 Internal Server Error_
* Adicionadas exceções:
    * `APIException` Base, extendida por todas as outras.
    * `ResourceNotFoundException`
        * `PetNotFoundException`
        * `UsuarioNotFoundException`
* Criado um `AuthenticationEntryPoint` personalizado para que o `ExceptionHandler` possa tratar a `AuthenticationException`.
* Controladores modificados para retornar as novas exceções.

# Por que foi feito

Para retornar informações mais úteis para o frontend quando ocorrem erros.
