### PR TITLE
Serviço de envio de emails

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,7 @@ dependencies {
 	implementation('org.springframework.boot:spring-boot-starter-data-rest')
 	implementation('org.springframework.boot:spring-boot-starter-web')
 	implementation('org.springframework.boot:spring-boot-starter-security')
+	implementation('org.springframework.boot:spring-boot-starter-mail')
 	implementation('io.jsonwebtoken:jjwt:0.9.1')
 
 	compile('io.springfox:springfox-swagger-ui:2.9.2')
@@ -61,6 +62,8 @@ dependencies {
 	compile('com.querydsl:querydsl-core:4.1.3')
 	compile('com.querydsl:querydsl-jpa:4.1.3')
 	compileOnly('com.querydsl:querydsl-apt:4.1.3:jpa')
+
+	implementation('com.sendgrid:sendgrid-java:4.0.1')
 	
 	compile("com.h2database:h2")
 	runtimeOnly('org.postgresql:postgresql')

--- a/src/main/java/br/com/academiadev/suicidesquad/email/EmailMessage.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/email/EmailMessage.java
@@ -1,0 +1,13 @@
+package br.com.academiadev.suicidesquad.email;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class EmailMessage {
+    private String remetente;
+    private String destinatario;
+    private String assunto;
+    private String conteudo;
+}

--- a/src/main/java/br/com/academiadev/suicidesquad/email/EmailTransport.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/email/EmailTransport.java
@@ -1,0 +1,5 @@
+package br.com.academiadev.suicidesquad.email;
+
+public interface EmailTransport {
+    void enviar(EmailMessage mensagem);
+}

--- a/src/main/java/br/com/academiadev/suicidesquad/email/EmailTransportFactory.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/email/EmailTransportFactory.java
@@ -21,7 +21,8 @@ public class EmailTransportFactory {
                 throw new RuntimeException("Can't send email: SendGrid API key not configured.");
             }
             return new SendGridEmailTransport(sendGridApiKey);
-        } else if (provider.equals("mailtrap")) {
+        }
+        if (provider.equals("mailtrap")) {
             String host = env.getProperty("app.email.mailtrap.host", "smtp.mailtrap.io");
             String port = env.getProperty("app.email.mailtrap.port", "2525");
             String username = env.getProperty("app.email.mailtrap.username");

--- a/src/main/java/br/com/academiadev/suicidesquad/email/EmailTransportFactory.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/email/EmailTransportFactory.java
@@ -1,0 +1,37 @@
+package br.com.academiadev.suicidesquad.email;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Component;
+
+@Component
+public class EmailTransportFactory {
+    private final Environment env;
+
+    @Autowired
+    public EmailTransportFactory(Environment env) {
+        this.env = env;
+    }
+
+    public EmailTransport buildTransport() {
+        String provider = env.getProperty("app.email.provider", "null");
+        if (provider.equals("sendgrid")) {
+            String sendGridApiKey = env.getProperty("app.email.sendgrid.api-key");
+            if (sendGridApiKey == null || sendGridApiKey.isEmpty()) {
+                throw new RuntimeException("Can't send email: SendGrid API key not configured.");
+            }
+            return new SendGridEmailTransport(sendGridApiKey);
+        } else if (provider.equals("mailtrap")) {
+            String host = env.getProperty("app.email.mailtrap.host", "smtp.mailtrap.io");
+            String port = env.getProperty("app.email.mailtrap.port", "2525");
+            String username = env.getProperty("app.email.mailtrap.username");
+            String password = env.getProperty("app.email.mailtrap.password");
+            if (username == null || username.isEmpty() || password == null || password.isEmpty()) {
+                throw new RuntimeException("Can't send email: Mailtrap credentials not configured.");
+            }
+            return new MailtrapEmailTransport(host, Integer.valueOf(port), username, password);
+        } else {
+            return new NullEmailTransport();
+        }
+    }
+}

--- a/src/main/java/br/com/academiadev/suicidesquad/email/EmailTransportFactory.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/email/EmailTransportFactory.java
@@ -30,8 +30,7 @@ public class EmailTransportFactory {
                 throw new RuntimeException("Can't send email: Mailtrap credentials not configured.");
             }
             return new MailtrapEmailTransport(host, Integer.valueOf(port), username, password);
-        } else {
-            return new NullEmailTransport();
         }
+        return new NullEmailTransport();
     }
 }

--- a/src/main/java/br/com/academiadev/suicidesquad/email/MailtrapEmailTransport.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/email/MailtrapEmailTransport.java
@@ -7,10 +7,10 @@ import javax.mail.MessagingException;
 import javax.mail.internet.MimeMessage;
 import java.util.Properties;
 
-public class MailtrapTransport implements EmailTransport {
+public class MailtrapEmailTransport implements EmailTransport {
     private JavaMailSenderImpl sender;
 
-    public MailtrapTransport(String host, int port, String username, String password) {
+    public MailtrapEmailTransport(String host, int port, String username, String password) {
         sender = new JavaMailSenderImpl();
         sender.setHost(host);
         sender.setPort(port);

--- a/src/main/java/br/com/academiadev/suicidesquad/email/MailtrapTransport.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/email/MailtrapTransport.java
@@ -1,0 +1,43 @@
+package br.com.academiadev.suicidesquad.email;
+
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+import org.springframework.mail.javamail.MimeMessageHelper;
+
+import javax.mail.MessagingException;
+import javax.mail.internet.MimeMessage;
+import java.util.Properties;
+
+public class MailtrapTransport implements EmailTransport {
+    private JavaMailSenderImpl sender;
+
+    public MailtrapTransport(String host, int port, String username, String password) {
+        sender = new JavaMailSenderImpl();
+        sender.setHost(host);
+        sender.setPort(port);
+        sender.setUsername(username);
+        sender.setPassword(password);
+        Properties props = sender.getJavaMailProperties();
+        props.put("mail.transport.protocol", "smtp");
+        props.put("mail.smtp.auth", "true");
+        props.put("mail.smtp.starttls.enable", "true");
+        props.put("mail.debug", "true");
+    }
+
+    @Override
+    public void enviar(EmailMessage mensagem) {
+        MimeMessage mimeMessage = sender.createMimeMessage();
+        MimeMessageHelper helper;
+        try {
+            helper = new MimeMessageHelper(mimeMessage, false, "utf-8");
+            helper.setFrom(mensagem.getRemetente());
+            helper.setTo(mensagem.getDestinatario());
+            helper.setSubject(mensagem.getAssunto());
+            helper.setText(mensagem.getConteudo(), true);
+        } catch (MessagingException e) {
+            // TODO: handle email error
+            throw new RuntimeException("Could not send email: " + e.toString());
+        }
+
+        sender.send(mimeMessage);
+    }
+}

--- a/src/main/java/br/com/academiadev/suicidesquad/email/NullEmailTransport.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/email/NullEmailTransport.java
@@ -1,0 +1,8 @@
+package br.com.academiadev.suicidesquad.email;
+
+public class NullEmailTransport implements EmailTransport {
+    @Override
+    public void enviar(EmailMessage mensagem) {
+        // Não faz nada!
+    }
+}

--- a/src/main/java/br/com/academiadev/suicidesquad/email/SendGridEmailTransport.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/email/SendGridEmailTransport.java
@@ -1,0 +1,33 @@
+package br.com.academiadev.suicidesquad.email;
+
+import com.sendgrid.*;
+
+import java.io.IOException;
+
+public class SendGridEmailTransport implements EmailTransport {
+
+    private SendGrid sendGrid;
+
+    public SendGridEmailTransport(String apiKey) {
+        sendGrid = new SendGrid(apiKey);
+    }
+
+    public void enviar(EmailMessage mensagem) {
+        Mail mail = new Mail(
+                new Email(mensagem.getRemetente()),
+                mensagem.getAssunto(),
+                new Email(mensagem.getDestinatario()),
+                new Content(mensagem.getConteudo(), "text/html")
+        );
+        Request request = new Request();
+        request.setMethod(Method.POST);
+        request.setEndpoint("mail/send");
+        try {
+            request.setBody(mail.build());
+            sendGrid.api(request);
+        } catch (IOException e) {
+            // TODO: handle email exception
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/br/com/academiadev/suicidesquad/service/EmailService.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/service/EmailService.java
@@ -48,7 +48,7 @@ public class EmailService {
             if (username == null || username.isEmpty() || password == null || password.isEmpty()) {
                 throw new RuntimeException("Can't send email: Mailtrap credentials not configured.");
             }
-            return new MailtrapTransport(host, Integer.valueOf(port), username, password);
+            return new MailtrapEmailTransport(host, Integer.valueOf(port), username, password);
         } else {
             return new NullEmailTransport();
         }

--- a/src/main/java/br/com/academiadev/suicidesquad/service/EmailService.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/service/EmailService.java
@@ -1,0 +1,83 @@
+package br.com.academiadev.suicidesquad.service;
+
+import br.com.academiadev.suicidesquad.email.*;
+import br.com.academiadev.suicidesquad.entity.Usuario;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Service;
+
+@Service
+public class EmailService {
+
+    @Value("${app.email.sender.domain:}")
+    private String SENDER_DOMAIN;
+
+    @Value("${app.email.sender.default-name:nao-responda}")
+    private String SENDER_DEFAULT_USER;
+
+    private final Environment env;
+
+    private EmailTransport transport;
+
+    @Autowired
+    public EmailService(Environment env) {
+        this.env = env;
+        this.transport = buildTransport();
+    }
+
+    // Construtor usado nos testes para injetar o mock de transport
+    public EmailService(Environment env, EmailTransport transport) {
+        this.env = env;
+        this.transport = transport;
+    }
+
+    private EmailTransport buildTransport() {
+        String provider = env.getProperty("app.email.provider", "null");
+        if (provider.equals("sendgrid")) {
+            String sendGridApiKey = env.getProperty("app.email.sendgrid.api-key");
+            if (sendGridApiKey == null || sendGridApiKey.isEmpty()) {
+                throw new RuntimeException("Can't send email: SendGrid API key not configured.");
+            }
+            return new SendGridEmailTransport(sendGridApiKey);
+        } else if (provider.equals("mailtrap")) {
+            String host = env.getProperty("app.email.mailtrap.host", "smtp.mailtrap.io");
+            String port = env.getProperty("app.email.mailtrap.port", "2525");
+            String username = env.getProperty("app.email.mailtrap.username");
+            String password = env.getProperty("app.email.mailtrap.password");
+            if (username == null || username.isEmpty() || password == null || password.isEmpty()) {
+                throw new RuntimeException("Can't send email: Mailtrap credentials not configured.");
+            }
+            return new MailtrapTransport(host, Integer.valueOf(port), username, password);
+        } else {
+            return new NullEmailTransport();
+        }
+    }
+
+    private String getEmailRemetente(String username) {
+        return String.format("%s@%s", username, getSenderDomain());
+    }
+
+    private String getSenderDomain() {
+        if (transport instanceof NullEmailTransport) {
+            return "example.com";
+        } else if (SENDER_DOMAIN != null && !SENDER_DOMAIN.isEmpty()) {
+            return SENDER_DOMAIN;
+        } else {
+            throw new RuntimeException("Can't send email: Sender domain not configured.");
+        }
+    }
+
+    public void enviarParaUsuario(Usuario destinatario, String assunto, String conteudo, String usernameRemetente) {
+        transport.enviar(new EmailMessage(
+                getEmailRemetente(usernameRemetente),
+                destinatario.getEmail(),
+                assunto,
+                conteudo
+        ));
+    }
+
+    public void enviarParaUsuario(Usuario destinatario, String assunto, String conteudo) {
+        enviarParaUsuario(destinatario, assunto, conteudo, SENDER_DEFAULT_USER);
+    }
+}

--- a/src/main/java/br/com/academiadev/suicidesquad/service/EmailService.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/service/EmailService.java
@@ -1,71 +1,31 @@
 package br.com.academiadev.suicidesquad.service;
 
-import br.com.academiadev.suicidesquad.email.*;
+import br.com.academiadev.suicidesquad.email.EmailMessage;
+import br.com.academiadev.suicidesquad.email.EmailTransport;
+import br.com.academiadev.suicidesquad.email.EmailTransportFactory;
 import br.com.academiadev.suicidesquad.entity.Usuario;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Service;
 
 @Service
 public class EmailService {
 
-    @Value("${app.email.sender.domain:}")
-    private String SENDER_DOMAIN;
+    private String senderDomain;
 
-    @Value("${app.email.sender.default-name:nao-responda}")
-    private String SENDER_DEFAULT_USER;
+    private String senderDefaultUser;
 
-    private final Environment env;
-
-    private EmailTransport transport;
+    private final EmailTransport transport;
 
     @Autowired
-    public EmailService(Environment env) {
-        this.env = env;
-        this.transport = buildTransport();
-    }
-
-    // Construtor usado nos testes para injetar o mock de transport
-    public EmailService(Environment env, EmailTransport transport) {
-        this.env = env;
-        this.transport = transport;
-    }
-
-    private EmailTransport buildTransport() {
-        String provider = env.getProperty("app.email.provider", "null");
-        if (provider.equals("sendgrid")) {
-            String sendGridApiKey = env.getProperty("app.email.sendgrid.api-key");
-            if (sendGridApiKey == null || sendGridApiKey.isEmpty()) {
-                throw new RuntimeException("Can't send email: SendGrid API key not configured.");
-            }
-            return new SendGridEmailTransport(sendGridApiKey);
-        } else if (provider.equals("mailtrap")) {
-            String host = env.getProperty("app.email.mailtrap.host", "smtp.mailtrap.io");
-            String port = env.getProperty("app.email.mailtrap.port", "2525");
-            String username = env.getProperty("app.email.mailtrap.username");
-            String password = env.getProperty("app.email.mailtrap.password");
-            if (username == null || username.isEmpty() || password == null || password.isEmpty()) {
-                throw new RuntimeException("Can't send email: Mailtrap credentials not configured.");
-            }
-            return new MailtrapEmailTransport(host, Integer.valueOf(port), username, password);
-        } else {
-            return new NullEmailTransport();
-        }
+    public EmailService(EmailTransportFactory transportFactory, @Value("${app.email.sender.domain}") String senderDomain, @Value("${app.email.sender.default-name:nao-responder}") String senderDefaultUser) {
+        this.transport = transportFactory.buildTransport();
+        this.senderDomain = senderDomain;
+        this.senderDefaultUser = senderDefaultUser;
     }
 
     private String getEmailRemetente(String username) {
-        return String.format("%s@%s", username, getSenderDomain());
-    }
-
-    private String getSenderDomain() {
-        if (transport instanceof NullEmailTransport) {
-            return "example.com";
-        } else if (SENDER_DOMAIN != null && !SENDER_DOMAIN.isEmpty()) {
-            return SENDER_DOMAIN;
-        } else {
-            throw new RuntimeException("Can't send email: Sender domain not configured.");
-        }
+        return String.format("%s@%s", username, this.senderDomain);
     }
 
     public void enviarParaUsuario(Usuario destinatario, String assunto, String conteudo, String usernameRemetente) {
@@ -78,6 +38,6 @@ public class EmailService {
     }
 
     public void enviarParaUsuario(Usuario destinatario, String assunto, String conteudo) {
-        enviarParaUsuario(destinatario, assunto, conteudo, SENDER_DEFAULT_USER);
+        enviarParaUsuario(destinatario, assunto, conteudo, this.senderDefaultUser);
     }
 }

--- a/src/main/resources/application-dev.properties.sample
+++ b/src/main/resources/application-dev.properties.sample
@@ -8,3 +8,10 @@ security.jwt.token.secret-key=
 app.social.facebook.enabled=false
 app.social.facebook.app-id=
 app.social.facebook.app-secret=
+
+# Opcional: Parâmetros para o envio de emails
+# Mude o provider para "mailtrap" e obtenha
+# as credenciais no site: https://mailtrap.io/
+app.email.provider=null
+app.email.mailtrap.username=
+app.email.mailtrap.password=

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -2,3 +2,6 @@ security.jwt.token.secret-key=${JWT_TOKEN_SECRET_KEY}
 app.social.facebook.enabled=false
 #app.social.facebook.app-id=${FACEBOOK_APP_ID}
 #app.social.facebook.app-secret=${FACEBOOK_APP_SECRET}
+
+app.email.provider=sendgrid
+app.email.sendgrid.api-key=${SENDGRID_API_KEY}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,3 +4,5 @@ spring.datasource.url=jdbc:h2:~/test;AUTO_SERVER=TRUE
 app.social.facebook.enabled = false
 app.social.facebook.backend-redirect-uri=http://localhost:8080/auth/facebook/callback
 app.social.facebook.frontend-redirect-uri=http://localhost:8081/
+
+app.email.sender.domain=404pets.com

--- a/src/test/java/br/com/academiadev/suicidesquad/service/EmailServiceTest.java
+++ b/src/test/java/br/com/academiadev/suicidesquad/service/EmailServiceTest.java
@@ -1,0 +1,54 @@
+package br.com.academiadev.suicidesquad.service;
+
+import br.com.academiadev.suicidesquad.email.EmailMessage;
+import br.com.academiadev.suicidesquad.email.NullEmailTransport;
+import br.com.academiadev.suicidesquad.entity.Usuario;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.Environment;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.*;
+
+@RunWith(SpringRunner.class)
+@ContextConfiguration(classes = {EmailService.class})
+@TestPropertySource(properties = {
+        "app.email.provider=null",
+        "app.email.sender.domain=404pets.com",
+        "app.email.mailtrap.username=27dcff65ac480e",
+        "app.email.mailtrap.password=5d423aa4109278",
+})
+public class EmailServiceTest {
+
+    @Autowired
+    private Environment environment;
+
+    @Test
+    public void sendEmail() {
+        Usuario usuario = Usuario.builder()
+                .nome("Fulano")
+                .email("fulano@example.com")
+                .build();
+
+        NullEmailTransport transport = mock(NullEmailTransport.class);
+        EmailService emailService = new EmailService(environment, transport);
+
+        emailService.enviarParaUsuario(
+                usuario,
+                "Email de teste",
+                "Olá, Fulano. Você foi escolhido para fazer parte dos nossos testes de unidade. Parabéns.");
+
+        ArgumentCaptor<EmailMessage> captor = ArgumentCaptor.forClass(EmailMessage.class);
+        verify(transport, times(1)).enviar(captor.capture());
+        EmailMessage captured = captor.getValue();
+
+        assertThat(captured.getDestinatario(), equalTo(usuario.getEmail()));
+        assertThat(captured.getAssunto(), equalTo("Email de teste"));
+    }
+}


### PR DESCRIPTION
Closes #41.

# O que foi feito

* Adicionadas dependências do Spring Boot Starter Email e do SendGrid.
* Adicionada a classe `EmailMessage`, que contém os dados de um email (remetente, destinatário, assunto, conteúdo).
* Adicionados "transportes", que encapsulam os processos de envio de emails de alguns provedores.
Eles implementam a interface `EmailTransport`, que tem um método `enviar(EmailMessage message)`.
    * `SendGridEmailTransport`: Usa a API do [SendGrid](https://sendgrid.com/), usado em produção.
    * `MailtrapEmailTransport`: Usa o [Mailtrap](https://mailtrap.io/) por meio de SMTP, usado em desenvolvimento.
    *  `NullEmailTransport`: Não envia emails. Usado nos testes (com mock).
* Adicionada a `EmailTransportFactory`, que instancia um dos transportes conforme as configurações nos arquivos de properties.
* Adicionado o `EmailService`, que usa a factory para obter um transporte, e define alguns métodos para encapsular o uso deles.
* Adicionado teste de unidade para o `EmailService`.
* Adicionadas novas configurações nas properties:
    * `app.email.sender.domain` Domínio remetente dos emails enviados (404pets.com)
    * `app.email.sender.default-name`: Usuário remetente. Opcional: o padrão é "nao-responder"
    * `app.email.provider` Escolha de transporte (null,  mailtrap, ou sendgrid)
    * `app.email.sendgrid.api-key`: Chave de API da SendGrid. Deve ser configurada quando em produção.
    * `app.email.mailtrap.username` e `app.email.mailtrap.password`: Credenciais do Mailtrap. Devem ser configurados no ambiente de desenvolvimento

# Por que foi feito

Para possibilitar a implementação das funcionalidades que requerem o envio de emails.

# O que falta fazer

Definir comportamento quando há erros no envio de emais (depends on #76).