### PR TITLE
Verificação de email existente e remoção da edição de email do usuário

### DIFF
--- a/src/main/java/br/com/academiadev/suicidesquad/controller/UsuarioController.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/controller/UsuarioController.java
@@ -4,6 +4,7 @@ import br.com.academiadev.suicidesquad.dto.UsuarioCreateDTO;
 import br.com.academiadev.suicidesquad.dto.UsuarioDTO;
 import br.com.academiadev.suicidesquad.dto.UsuarioEditDTO;
 import br.com.academiadev.suicidesquad.entity.Usuario;
+import br.com.academiadev.suicidesquad.exception.EmailExistenteException;
 import br.com.academiadev.suicidesquad.exception.UsuarioNotFoundException;
 import br.com.academiadev.suicidesquad.mapper.UsuarioMapper;
 import br.com.academiadev.suicidesquad.service.UsuarioService;
@@ -47,11 +48,15 @@ public class UsuarioController {
 
     @ApiOperation(value = "Cria o usuário")
     @ApiResponses(value = {
-            @ApiResponse(code = 201, message = "Usuário criado com sucesso")
+            @ApiResponse(code = 201, message = "Usuário criado com sucesso"),
+            @ApiResponse(code = 400, message = "Usuário inválido"),
     })
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/usuarios")
     UsuarioDTO createUsuario(@Valid @RequestBody UsuarioCreateDTO usuarioCreateDTO) {
+        if (usuarioService.existsByEmail(usuarioCreateDTO.getEmail())) {
+            throw new EmailExistenteException();
+        }
         Usuario usuario = usuarioMapper.toEntity(usuarioCreateDTO);
         return usuarioMapper.toDto(usuarioService.save(usuario));
     }

--- a/src/main/java/br/com/academiadev/suicidesquad/dto/UsuarioEditDTO.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/dto/UsuarioEditDTO.java
@@ -15,11 +15,6 @@ public class UsuarioEditDTO {
     @NotNull
     private String nome;
 
-    @ApiModelProperty(value = "E-mail", example = "fulano@example.com", required = true)
-    @NotNull
-    @Email
-    private String email;
-
     @ApiModelProperty(value = "Senha")
     private String senha;
 

--- a/src/main/java/br/com/academiadev/suicidesquad/exception/EmailExistenteException.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/exception/EmailExistenteException.java
@@ -1,0 +1,4 @@
+package br.com.academiadev.suicidesquad.exception;
+
+public class EmailExistenteException extends APIException{
+}

--- a/src/main/java/br/com/academiadev/suicidesquad/exception/handler/RestResponseEntityExceptionHandler.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/exception/handler/RestResponseEntityExceptionHandler.java
@@ -61,7 +61,7 @@ public class RestResponseEntityExceptionHandler extends ResponseEntityExceptionH
     @ExceptionHandler({
             EmailExistenteException.class
     })
-    private ResponseEntity<Object> handleEmailExistete(EmailExistenteException e, WebRequest request) throws JsonProcessingException {
+    private ResponseEntity<Object> handleEmailExistente(EmailExistenteException e, WebRequest request) throws JsonProcessingException {
         final ObjectNode errorNode = objectMapper.createObjectNode();
         errorNode.put("code", 400);
         errorNode.put("error", "Este email já foi usado. Por favor, use outro endereço.");

--- a/src/main/java/br/com/academiadev/suicidesquad/exception/handler/RestResponseEntityExceptionHandler.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/exception/handler/RestResponseEntityExceptionHandler.java
@@ -1,5 +1,6 @@
 package br.com.academiadev.suicidesquad.exception.handler;
 
+import br.com.academiadev.suicidesquad.exception.EmailExistenteException;
 import br.com.academiadev.suicidesquad.exception.ResourceNotFoundException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -55,6 +56,18 @@ public class RestResponseEntityExceptionHandler extends ResponseEntityExceptionH
         final HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON_UTF8);
         return handleExceptionInternal(e, objectMapper.writeValueAsString(errorNode), headers, HttpStatus.NOT_FOUND, request);
+    }
+
+    @ExceptionHandler({
+            EmailExistenteException.class
+    })
+    private ResponseEntity<Object> handleEmailExistete(EmailExistenteException e, WebRequest request) throws JsonProcessingException {
+        final ObjectNode errorNode = objectMapper.createObjectNode();
+        errorNode.put("code", 400);
+        errorNode.put("error", "Este email já foi usado. Por favor, use outro endereço.");
+        final HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON_UTF8);
+        return handleExceptionInternal(e, objectMapper.writeValueAsString(errorNode), headers, HttpStatus.BAD_REQUEST, request);
     }
 
     @Override

--- a/src/main/java/br/com/academiadev/suicidesquad/mapper/UsuarioMapper.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/mapper/UsuarioMapper.java
@@ -34,7 +34,6 @@ public abstract class UsuarioMapper {
 
     @Mappings({
             @Mapping(target = "nome"),
-            @Mapping(target = "email"),
             @Mapping(target = "senha", ignore = true),
             @Mapping(target = "sexo", defaultValue = "NAO_INFORMADO"),
             @Mapping(target = "dataNascimento", source = "data_nascimento", dateFormat = "yyyy-MM-dd"),

--- a/src/main/java/br/com/academiadev/suicidesquad/repository/UsuarioRepository.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/repository/UsuarioRepository.java
@@ -11,4 +11,5 @@ import java.util.Optional;
 public interface UsuarioRepository extends JpaRepository<Usuario, Long> {
     Optional<Usuario> findByEmail(String email);
     Optional<Usuario> findByFacebookUserId(String facebookUserId);
+    boolean existsByEmail(String email);
 }

--- a/src/main/java/br/com/academiadev/suicidesquad/service/UsuarioService.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/service/UsuarioService.java
@@ -41,6 +41,10 @@ public class UsuarioService {
         return usuarioRepository.existsById(idUsuario);
     }
 
+    public boolean existsByEmail(String email) {
+        return usuarioRepository.existsByEmail(email);
+    }
+
     public void deleteById(Long idUsuario) {
         usuarioRepository.deleteById(idUsuario);
     }

--- a/src/test/java/br/com/academiadev/suicidesquad/controller/UsuarioControllerTest.java
+++ b/src/test/java/br/com/academiadev/suicidesquad/controller/UsuarioControllerTest.java
@@ -177,7 +177,6 @@ public class UsuarioControllerTest {
 
         String usuarioJson = "{" +
                 "   \"nome\": \"Novo nome\"," +
-                "   \"email\": \"novo.email@example.com\"," +
                 "   \"telefones\": [" +
                 "       {" +
                 "           \"numero\": \"(47) 99999-9999\"" +
@@ -226,7 +225,6 @@ public class UsuarioControllerTest {
 
         Map<String, String> usuarioJson = new HashMap<>();
         usuarioJson.put("nome", "Novo nome");
-        usuarioJson.put("email", "usuario.b.novo.email@example.com");
 
         String tokenA = jwtTokenProvider.getToken(usuarioA.getUsername(), Collections.emptyList());
         mvc.perform(put(String.format("/usuarios/%d", usuarioB.getId()))

--- a/src/test/java/br/com/academiadev/suicidesquad/controller/UsuarioControllerTest.java
+++ b/src/test/java/br/com/academiadev/suicidesquad/controller/UsuarioControllerTest.java
@@ -79,6 +79,21 @@ public class UsuarioControllerTest {
 
     @Test
     public void criarUsuario_quandoInvalido_entaoErro() throws Exception {
+        Usuario usuarioExistente = usuarioService.save(buildUsuario());
+
+        final Map<String, String> usuarioNovoJson = new HashMap<>();
+        usuarioNovoJson.put("nome", "Fulano");
+        usuarioNovoJson.put("email", usuarioExistente.getEmail());
+        usuarioNovoJson.put("senha", "hunter2");
+
+        mvc.perform(post("/usuarios")
+                .content(objectMapper.writeValueAsString(usuarioNovoJson))
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    public void criarUsuario_quandoEmailExistente_entaoErro() throws Exception {
         final Map<String, String> usuarioJson = new HashMap<>();
         usuarioJson.put("nome", "Fulano");
 
@@ -177,7 +192,7 @@ public class UsuarioControllerTest {
                 .andExpect(status().isOk());
 
         assertThat(usuario.getNome(), equalTo("Novo nome"));
-        assertThat(usuario.getEmail(), equalTo("novo.email@example.com"));
+        assertThat(usuario.getEmail(), equalTo("fulano@example.com"));
         assertThat(usuario.getTelefones().get(0).getNumero(), equalTo("(47) 99999-9999"));
         assertThat(usuario.getTelefones().get(0).getUsuario().getId(), equalTo(usuario.getId()));
         assertThat(usuario.getPets().get(0).getId(), equalTo(pet.getId()));
@@ -188,14 +203,10 @@ public class UsuarioControllerTest {
     public void editarUsuario_quandoInvalidoEAutorizado_entaoErro() throws Exception {
         final Usuario usuario = usuarioService.save(buildUsuario());
 
-        Map<String, String> usuarioJson = new HashMap<>();
-        usuarioJson.put("nome", "Novo nome");
-        usuarioJson.put("email", "email inválido");
-
         String token = jwtTokenProvider.getToken(usuario.getUsername(), Collections.emptyList());
         mvc.perform(put(String.format("/usuarios/%d", usuario.getId()))
                 .header("Authorization", "Bearer " + token)
-                .content(objectMapper.writeValueAsString(usuarioJson))
+                .content(objectMapper.writeValueAsString("{}"))
                 .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isBadRequest());
     }

--- a/src/test/java/br/com/academiadev/suicidesquad/mapper/UsuarioMapperTest.java
+++ b/src/test/java/br/com/academiadev/suicidesquad/mapper/UsuarioMapperTest.java
@@ -52,7 +52,6 @@ public class UsuarioMapperTest {
 
         UsuarioEditDTO usuarioB_EditDTO = new UsuarioEditDTO();
         usuarioB_EditDTO.setNome(usuarioB.getNome());
-        usuarioB_EditDTO.setEmail(usuarioB.getEmail());
 
         LocalizacaoDTO localizacaoB_DTO = new LocalizacaoDTO();
         localizacaoB_DTO.setBairro("Floresta");
@@ -75,7 +74,6 @@ public class UsuarioMapperTest {
 
         UsuarioEditDTO usuarioB_EditDTO = new UsuarioEditDTO();
         usuarioB_EditDTO.setNome(usuarioB.getNome());
-        usuarioB_EditDTO.setEmail(usuarioB.getEmail());
 
         LocalizacaoDTO localizacaoA_DTO = new LocalizacaoDTO();
         localizacaoA_DTO.setBairro(localizacaoA.getBairro());


### PR DESCRIPTION
Closes #80 

# O que foi feito

* Adicionada `EmailExistenteException`, retornada pelo `UsuarioController` quando o usuário a ser criado tem um email que já foi usado por outro usuário.
* Adicionado método `existsByEmail` ao repositório e serviço do usuário, para implementar a funcionalidade acima.
* Adicionado handler para a nova exceção.
* Campo `email` removido no `UsuarioEditDTO`, e testes atualizados em correspondência.

# Por que foi feito

Para manter a integridade dos dados.
