### PR TITLE
Endpoints de redefinição de senha

### DIFF
--- a/src/main/java/br/com/academiadev/suicidesquad/config/SecurityConfig.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/config/SecurityConfig.java
@@ -72,6 +72,11 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         "/usuarios",
                     "/usuarios/{id}"
                 ).permitAll()
+                .antMatchers(
+                        HttpMethod.PUT,
+                        "/senhas/requisitar_redefinicao",
+                        "/senhas/redefinir"
+                ).permitAll()
                 .anyRequest().authenticated()
                 .and()
             .exceptionHandling()

--- a/src/main/java/br/com/academiadev/suicidesquad/controller/SenhaController.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/controller/SenhaController.java
@@ -1,0 +1,68 @@
+package br.com.academiadev.suicidesquad.controller;
+
+import br.com.academiadev.suicidesquad.dto.AlterarSenhaDTO;
+import br.com.academiadev.suicidesquad.dto.IniciarRedefinicaoSenhaDTO;
+import br.com.academiadev.suicidesquad.dto.RedefinirSenhaDTO;
+import br.com.academiadev.suicidesquad.entity.Usuario;
+import br.com.academiadev.suicidesquad.exception.UsuarioNotFoundException;
+import br.com.academiadev.suicidesquad.service.PasswordService;
+import br.com.academiadev.suicidesquad.service.RedefinicaoSenhaService;
+import br.com.academiadev.suicidesquad.service.UsuarioService;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+
+@RestController
+@RequestMapping("/senhas/")
+public class SenhaController {
+
+    private final UsuarioService usuarioService;
+
+    private final RedefinicaoSenhaService redefinicaoSenhaService;
+
+    @Autowired
+    public SenhaController(RedefinicaoSenhaService redefinicaoSenhaService, UsuarioService usuarioService) {
+        this.redefinicaoSenhaService = redefinicaoSenhaService;
+        this.usuarioService = usuarioService;
+    }
+
+    @PutMapping("alterar")
+    @ApiResponses({
+            @ApiResponse(code = 200, message = "Senha alterada"),
+            @ApiResponse(code = 400, message = "Campos inválidos"),
+            @ApiResponse(code = 401, message = "Senha atual incorreta"),
+            @ApiResponse(code = 403, message = "Não autorizado"),
+    })
+    public void alterarSenha(@Valid @RequestBody AlterarSenhaDTO alterarSenhaDTO, @AuthenticationPrincipal Usuario usuarioLogado) {
+        if (!PasswordService.encoder().matches(alterarSenhaDTO.getSenha_atual(), usuarioLogado.getPassword())) {
+           throw new BadCredentialsException("Senha atual incorreta");
+        }
+        usuarioLogado.setSenha(PasswordService.encoder().encode(alterarSenhaDTO.getSenha_nova()));
+    }
+
+    @PutMapping("requisitar_redefinicao")
+    @ApiResponses({
+            @ApiResponse(code = 200, message = "Token enviado para o email"),
+            @ApiResponse(code = 400, message = "Campos inválidos"),
+            @ApiResponse(code = 404, message = "Usuário com este email não foi encontrado")
+    })
+    public void requisitarRedefinicaoSenha(@Valid @RequestBody IniciarRedefinicaoSenhaDTO iniciarRedefinicaoSenhaDTO) {
+        Usuario usuario = usuarioService.findByEmail(iniciarRedefinicaoSenhaDTO.getEmail())
+                .orElseThrow(UsuarioNotFoundException::new);
+        redefinicaoSenhaService.iniciarRedefinicao(usuario);
+    }
+
+    @PutMapping("redefinir")
+    @ApiResponses({
+            @ApiResponse(code = 200, message = "Senha redefinida"),
+            @ApiResponse(code = 400, message = "Token inválido")
+    })
+    public void redefinirSenha(@Valid @RequestBody RedefinirSenhaDTO redefinirSenhaDTO) {
+        redefinicaoSenhaService.completarRedefinicao(redefinirSenhaDTO.getToken(), redefinirSenhaDTO.getSenha_nova());
+    }
+}

--- a/src/main/java/br/com/academiadev/suicidesquad/dto/AlterarSenhaDTO.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/dto/AlterarSenhaDTO.java
@@ -1,0 +1,13 @@
+package br.com.academiadev.suicidesquad.dto;
+
+import lombok.Data;
+
+import javax.validation.constraints.NotNull;
+
+@Data
+public class AlterarSenhaDTO {
+    @NotNull
+    private String senha_atual;
+    @NotNull
+    private String senha_nova;
+}

--- a/src/main/java/br/com/academiadev/suicidesquad/dto/IniciarRedefinicaoSenhaDTO.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/dto/IniciarRedefinicaoSenhaDTO.java
@@ -1,0 +1,11 @@
+package br.com.academiadev.suicidesquad.dto;
+
+import lombok.Data;
+
+import javax.validation.constraints.NotNull;
+
+@Data
+public class IniciarRedefinicaoSenhaDTO {
+    @NotNull
+    private String email;
+}

--- a/src/main/java/br/com/academiadev/suicidesquad/dto/RedefinirSenhaDTO.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/dto/RedefinirSenhaDTO.java
@@ -1,0 +1,13 @@
+package br.com.academiadev.suicidesquad.dto;
+
+import lombok.Data;
+
+import javax.validation.constraints.NotNull;
+
+@Data
+public class RedefinirSenhaDTO {
+    @NotNull
+    private String token;
+    @NotNull
+    private String senha_nova;
+}

--- a/src/main/java/br/com/academiadev/suicidesquad/dto/UsuarioEditDTO.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/dto/UsuarioEditDTO.java
@@ -15,9 +15,6 @@ public class UsuarioEditDTO {
     @NotNull
     private String nome;
 
-    @ApiModelProperty(value = "Senha")
-    private String senha;
-
     @ApiModelProperty(value = "Sexo", allowableValues = "NAO_INFORMADO,MASCULINO,FEMININO")
     private String sexo;
 

--- a/src/main/java/br/com/academiadev/suicidesquad/exception/handler/RestResponseEntityExceptionHandler.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/exception/handler/RestResponseEntityExceptionHandler.java
@@ -1,6 +1,7 @@
 package br.com.academiadev.suicidesquad.exception.handler;
 
 import br.com.academiadev.suicidesquad.exception.EmailExistenteException;
+import br.com.academiadev.suicidesquad.exception.InvalidTokenException;
 import br.com.academiadev.suicidesquad.exception.ResourceNotFoundException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -65,6 +66,18 @@ public class RestResponseEntityExceptionHandler extends ResponseEntityExceptionH
         final ObjectNode errorNode = objectMapper.createObjectNode();
         errorNode.put("code", 400);
         errorNode.put("error", "Este email já foi usado. Por favor, use outro endereço.");
+        final HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON_UTF8);
+        return handleExceptionInternal(e, objectMapper.writeValueAsString(errorNode), headers, HttpStatus.BAD_REQUEST, request);
+    }
+
+    @ExceptionHandler({
+            InvalidTokenException.class
+    })
+    private ResponseEntity<Object> hnadleInvalidToken(InvalidTokenException e, WebRequest request) throws JsonProcessingException {
+        final ObjectNode errorNode = objectMapper.createObjectNode();
+        errorNode.put("code", 400);
+        errorNode.put("error", "Este token é inválido.");
         final HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON_UTF8);
         return handleExceptionInternal(e, objectMapper.writeValueAsString(errorNode), headers, HttpStatus.BAD_REQUEST, request);

--- a/src/main/java/br/com/academiadev/suicidesquad/exception/handler/RestResponseEntityExceptionHandler.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/exception/handler/RestResponseEntityExceptionHandler.java
@@ -74,7 +74,7 @@ public class RestResponseEntityExceptionHandler extends ResponseEntityExceptionH
     @ExceptionHandler({
             InvalidTokenException.class
     })
-    private ResponseEntity<Object> hnadleInvalidToken(InvalidTokenException e, WebRequest request) throws JsonProcessingException {
+    private ResponseEntity<Object> handleInvalidToken(InvalidTokenException e, WebRequest request) throws JsonProcessingException {
         final ObjectNode errorNode = objectMapper.createObjectNode();
         errorNode.put("code", 400);
         errorNode.put("error", "Este token é inválido.");

--- a/src/main/java/br/com/academiadev/suicidesquad/mapper/UsuarioMapper.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/mapper/UsuarioMapper.java
@@ -34,7 +34,6 @@ public abstract class UsuarioMapper {
 
     @Mappings({
             @Mapping(target = "nome"),
-            @Mapping(target = "senha", ignore = true),
             @Mapping(target = "sexo", defaultValue = "NAO_INFORMADO"),
             @Mapping(target = "dataNascimento", source = "data_nascimento", dateFormat = "yyyy-MM-dd"),
             @Mapping(target = "localizacao", ignore = true),
@@ -55,13 +54,6 @@ public abstract class UsuarioMapper {
     @AfterMapping
     public void mapearSenha(UsuarioCreateDTO usuarioCreateDTO, @MappingTarget Usuario entity) {
         entity.setSenha(PasswordService.encoder().encode(usuarioCreateDTO.getSenha()));
-    }
-
-    @AfterMapping
-    public void mapearSenha(UsuarioEditDTO usuarioEditDTO, @MappingTarget Usuario entity) {
-        if (usuarioEditDTO.getSenha() != null) {
-            entity.setSenha(PasswordService.encoder().encode(usuarioEditDTO.getSenha()));
-        }
     }
 
     @AfterMapping

--- a/src/test/java/br/com/academiadev/suicidesquad/controller/SenhaControllerTest.java
+++ b/src/test/java/br/com/academiadev/suicidesquad/controller/SenhaControllerTest.java
@@ -1,0 +1,147 @@
+package br.com.academiadev.suicidesquad.controller;
+
+import br.com.academiadev.suicidesquad.entity.Usuario;
+import br.com.academiadev.suicidesquad.security.JwtTokenProvider;
+import br.com.academiadev.suicidesquad.service.EmailService;
+import br.com.academiadev.suicidesquad.service.PasswordService;
+import br.com.academiadev.suicidesquad.service.TokenService;
+import br.com.academiadev.suicidesquad.service.UsuarioService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+
+import javax.transaction.Transactional;
+import java.util.Collections;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+public class SenhaControllerTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Autowired
+    private UsuarioService usuarioService;
+
+    @Autowired
+    private TokenService tokenService;
+
+    @MockBean
+    private EmailService emailService;
+
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private Usuario usuario;
+    private String sessionToken;
+
+    @Before
+    public void setUp() {
+        usuario = usuarioService.save(Usuario.builder()
+                .nome("Fulano")
+                .email("fulano@example.com")
+                .senha(PasswordService.encoder().encode("senha1"))
+                .build());
+        sessionToken = jwtTokenProvider.getToken(usuario.getUsername(), Collections.emptyList());
+    }
+
+    @Test
+    public void alterarSenha_quandoSenhaAtualCorreta_entaoSucesso() throws Exception {
+        String oldHash = usuario.getSenha();
+
+        ObjectNode alterarSenhaJson = objectMapper.createObjectNode();
+        alterarSenhaJson.put("senha_atual", "senha1");
+        alterarSenhaJson.put("senha_nova", "senha2");
+
+        mvc.perform(put("/senhas/alterar")
+                .content(objectMapper.writeValueAsString(alterarSenhaJson))
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer " + sessionToken))
+                .andExpect(status().isOk());
+
+        assertThat(usuario.getSenha(), not(equalTo(oldHash)));
+    }
+
+    @Test
+    public void alterarSenha_quandoSenhaAtualIncorreta_entaoErro() throws Exception {
+        String oldHash = usuario.getSenha();
+
+        ObjectNode alterarSenhaJson = objectMapper.createObjectNode();
+        alterarSenhaJson.put("senha_atual", "senha errada");
+        alterarSenhaJson.put("senha_nova", "senha2");
+
+        mvc.perform(put("/senhas/alterar")
+                .content(objectMapper.writeValueAsString(alterarSenhaJson))
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer " + sessionToken))
+                .andExpect(status().isUnauthorized());
+
+        assertThat(usuario.getSenha(), equalTo(oldHash));
+    }
+
+    @Test
+    public void redefinirSenha_quandoTokenValido_entaoSucesso() throws Exception {
+        String oldHash = usuario.getSenha();
+
+        mvc.perform(put("/senhas/requisitar_redefinicao")
+                .content("{\"email\": \"fulano@example.com\"}")
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+
+        String tokenRedefinicao = tokenService.generateRedefinicaoSenhaToken(usuario);
+        verify(emailService, times(1))
+                .enviarParaUsuario(eq(usuario), any(String.class), contains(tokenRedefinicao));
+
+        ObjectNode redefinirSenhaJson = objectMapper.createObjectNode();
+        redefinirSenhaJson.put("token", tokenRedefinicao);
+        redefinirSenhaJson.put("senha_nova", "senha3");
+
+        mvc.perform(put("/senhas/redefinir")
+                .content(objectMapper.writeValueAsString(redefinirSenhaJson))
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer " + sessionToken))
+                .andExpect(status().isOk());
+
+        assertThat(usuario.getSenha(), not(equalTo(oldHash)));
+    }
+
+    @Test
+    public void redefinirSenha_quandoTokenInvalido_entaoErro() throws Exception {
+        String oldHash = usuario.getSenha();
+
+        ObjectNode redefinirSenhaJson = objectMapper.createObjectNode();
+        redefinirSenhaJson.put("token", "token inválido");
+        redefinirSenhaJson.put("senha_nova", "senha3");
+
+        mvc.perform(put("/senhas/redefinir")
+                .content(objectMapper.writeValueAsString(redefinirSenhaJson))
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer " + sessionToken))
+                .andExpect(status().isBadRequest());
+
+        assertThat(usuario.getSenha(), equalTo(oldHash));
+    }
+}

--- a/src/test/java/br/com/academiadev/suicidesquad/service/RedefinicaoSenhaServiceTest.java
+++ b/src/test/java/br/com/academiadev/suicidesquad/service/RedefinicaoSenhaServiceTest.java
@@ -62,7 +62,9 @@ public class RedefinicaoSenhaServiceTest {
 
         final String token = "um token bem seguro";
         when(tokenService.validateRedefinicaoSenhaToken(usuario, token)).thenReturn(true);
-        redefinicaoSenhaService.completarRedefinicao(usuario, token, "senha2");
+        when(tokenService.getEmailFromRedefinicaoSenhaToken(token)).thenReturn(usuario.getEmail());
+        when(usuarioService.findByEmail(usuario.getEmail())).thenReturn(Optional.of(usuario));
+        redefinicaoSenhaService.completarRedefinicao(token, "senha2");
 
         ArgumentCaptor<Usuario> captor = ArgumentCaptor.forClass(Usuario.class);
         verify(usuarioService, times(1)).save(captor.capture());
@@ -77,6 +79,6 @@ public class RedefinicaoSenhaServiceTest {
         final String token = "um token errado";
         when(tokenService.validateRedefinicaoSenhaToken(usuario, token)).thenReturn(false);
 
-        redefinicaoSenhaService.completarRedefinicao(usuario, token, "senha2");
+        redefinicaoSenhaService.completarRedefinicao(token, "senha2");
     }
 }


### PR DESCRIPTION
Closes #39

# O que foi feito

* Adicionados métodos que ignoram a assinatura digital do token de redefinição de senha, para obter o email do usuário a ser alterado. Isso é necessário pois parte da chave da assinatura é o hash da senha atual do usuário. O token é validado após obter o usuário do banco, por meio do email.
* Adicionados endpoints para alterar, requisitar redefinição, e redefinir a senha de um usuário.
    * `PUT /senhas/alterar` Recebe a senha atual do usuário logado, e muda para uma nova senha.
    * `PUT /senhas/requisitar_redefinicao` Envia para o email fornecido um token de redefinição.
    * `PUT /senhas/redefinir` Aceita o token enviado por email, junto da nova senha.
* Adicionados DTOs para enviar para estes endpoints.
* Adicionadas exceções na autenticação dos requests para os endpoints de redefinição de senha, para que possam ser acessados por usuários não logados.
* Removido o campo de senha da edição do usuário. Substituído pelo endpoint de alteração de senha.
* Adicionado exception handler para o `InvalidTokenException`.
* Adicionados testes para o novo controlador.

# Por que foi feito

Para expor a funcionalidade de redefinição de senha implementada no PR #81.