### PR TITLE
Adicionar opção de email público à edição do usuário

### DIFF
--- a/src/main/java/br/com/academiadev/suicidesquad/dto/UsuarioCreateDTO.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/dto/UsuarioCreateDTO.java
@@ -33,5 +33,5 @@ public class UsuarioCreateDTO {
     private LocalizacaoDTO localizacao;
 
     @ApiModelProperty(value = "email visível nos anúncios")
-    private boolean emailPublico;
+    private boolean email_publico;
 }

--- a/src/main/java/br/com/academiadev/suicidesquad/dto/UsuarioEditDTO.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/dto/UsuarioEditDTO.java
@@ -26,4 +26,7 @@ public class UsuarioEditDTO {
 
     @ApiModelProperty(value = "Telefones")
     private Set<TelefoneDTO> telefones;
+
+    @ApiModelProperty(value = "Email visível nos anúncios?")
+    private boolean email_publico;
 }

--- a/src/main/java/br/com/academiadev/suicidesquad/mapper/UsuarioMapper.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/mapper/UsuarioMapper.java
@@ -28,7 +28,8 @@ public abstract class UsuarioMapper {
             @Mapping(target = "senha", ignore = true),
             @Mapping(target = "sexo", defaultValue = "NAO_INFORMADO"),
             @Mapping(target = "dataNascimento", source = "data_nascimento", dateFormat = "yyyy-MM-dd"),
-            @Mapping(target = "localizacao", ignore = true)
+            @Mapping(target = "localizacao", ignore = true),
+            @Mapping(target = "emailPublico", source = "email_publico", defaultValue = "true")
     })
     public abstract Usuario toEntity(UsuarioCreateDTO dto);
 

--- a/src/main/java/br/com/academiadev/suicidesquad/mapper/UsuarioMapper.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/mapper/UsuarioMapper.java
@@ -37,7 +37,8 @@ public abstract class UsuarioMapper {
             @Mapping(target = "sexo", defaultValue = "NAO_INFORMADO"),
             @Mapping(target = "dataNascimento", source = "data_nascimento", dateFormat = "yyyy-MM-dd"),
             @Mapping(target = "localizacao", ignore = true),
-            @Mapping(target = "telefones")
+            @Mapping(target = "telefones"),
+            @Mapping(target = "emailPublico", source = "email_publico")
     })
     public abstract Usuario updateEntity(UsuarioEditDTO dto, @MappingTarget Usuario entity);
 

--- a/src/test/java/br/com/academiadev/suicidesquad/controller/UsuarioControllerTest.java
+++ b/src/test/java/br/com/academiadev/suicidesquad/controller/UsuarioControllerTest.java
@@ -177,6 +177,7 @@ public class UsuarioControllerTest {
 
         String usuarioJson = "{" +
                 "   \"nome\": \"Novo nome\"," +
+                "   \"email_publico\": \"false\"," +
                 "   \"telefones\": [" +
                 "       {" +
                 "           \"numero\": \"(47) 99999-9999\"" +
@@ -192,6 +193,7 @@ public class UsuarioControllerTest {
 
         assertThat(usuario.getNome(), equalTo("Novo nome"));
         assertThat(usuario.getEmail(), equalTo("fulano@example.com"));
+        assertThat(usuario.getEmailPublico(), nullValue());
         assertThat(usuario.getTelefones().get(0).getNumero(), equalTo("(47) 99999-9999"));
         assertThat(usuario.getTelefones().get(0).getUsuario().getId(), equalTo(usuario.getId()));
         assertThat(usuario.getPets().get(0).getId(), equalTo(pet.getId()));


### PR DESCRIPTION
Closes #84

# O que foi feito

Adicionado e mapeado o campo `email_publico` no `UsuarioCreateDTO` e `UsuarioEditDTO`

# Por que foi feito

Para poder editar pela API