### PR TITLE
Email de notificação de inatividade dos pets

### DIFF
--- a/src/main/java/br/com/academiadev/suicidesquad/SuicidesquadApplication.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/SuicidesquadApplication.java
@@ -2,8 +2,10 @@ package br.com.academiadev.suicidesquad;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class SuicidesquadApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/br/com/academiadev/suicidesquad/entity/Pet.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/entity/Pet.java
@@ -7,6 +7,7 @@ import lombok.*;
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
+import java.time.LocalDateTime;
 import java.util.*;
 
 @Data
@@ -73,6 +74,8 @@ public class Pet extends AuditableEntity<Long> {
 
     @Size(min = 1, max = 2000)
     private String descricao;
+
+    private LocalDateTime dataNotificacaoDeInatividade;
 
     @ManyToOne
     @JoinColumn(name = "id_usuario")

--- a/src/main/java/br/com/academiadev/suicidesquad/monitor/PetMonitor.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/monitor/PetMonitor.java
@@ -1,0 +1,90 @@
+package br.com.academiadev.suicidesquad.monitor;
+
+import br.com.academiadev.suicidesquad.entity.Pet;
+import br.com.academiadev.suicidesquad.service.EmailService;
+import br.com.academiadev.suicidesquad.service.PetService;
+import br.com.academiadev.suicidesquad.service.UsuarioService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import javax.transaction.Transactional;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Component
+@Transactional
+public class PetMonitor {
+    private final UsuarioService usuarioService;
+
+    private final PetService petService;
+
+    private final EmailService emailService;
+
+    @Autowired
+    public PetMonitor(PetService petService, EmailService emailService, UsuarioService usuarioService) {
+        this.petService = petService;
+        this.emailService = emailService;
+        this.usuarioService = usuarioService;
+    }
+
+    private String buildCorpoEmailInatividade(List<Pet> pets) {
+        StringBuilder builder = new StringBuilder();
+        builder.append("<p>Olá, ").append(pets.get(0).getUsuario().getNome()).append(".</p>");
+
+        if (pets.size() > 1) {
+            builder
+                    .append("<p>Faz algum tempo que seus pets não recebem atualizações. ")
+                    .append("Caso haja alguma novidade, clique nos pets para acessá-los.</p>");
+        } else {
+            builder
+                    .append("<p>Faz algum tempo que o seu pet não recebe atualização</p>")
+                    .append("<p>Se houver alguma novidade, acesse a página do pet.</p>");
+        }
+
+        builder.append("<ul>");
+        pets.stream().map(this::buildItemPet).forEach(builder::append);
+        builder.append("</ul>");
+        return builder.toString();
+    }
+
+    private String buildItemPet(Pet pet) {
+        // TODO linkar o pet
+        StringBuilder builder = new StringBuilder();
+        builder.append("<li>");
+        if (pet.getNome() != null) {
+            builder.append(pet.getNome());
+        } else if (pet.getRaca() != null) {
+            builder.append(pet.getRaca()).append(" ").append(pet.getCategoria());
+        } else {
+            builder.append(pet.getTipo()).append(" ").append(pet.getCategoria());
+        }
+        builder.append("</li>");
+        return builder.toString();
+    }
+
+    private void enviarEmailInatividade(List<Pet> pets) {
+        if (pets.size() == 0) {
+            return;
+        }
+
+        pets.forEach(pet -> {
+            pet.setDataNotificacaoDeInatividade(LocalDateTime.now());
+            petService.save(pet);
+        });
+
+        emailService.enviarParaUsuario(
+                pets.get(0).getUsuario(),
+                pets.size() > 1 ? "Alguma notícia dos seus pets?" : "Alguma notícia do seu pet?",
+                buildCorpoEmailInatividade(pets)
+        );
+    }
+
+    // A cada 1 dia, enviar emails de notificação de inatividade
+    @Scheduled(fixedRate = 86400000)
+    public void notificarInatividade() {
+        usuarioService.findAll().stream()
+                .map(petService::findPetsInativosNaoNotificadosDoUsuario)
+                .forEach(this::enviarEmailInatividade);
+    }
+}

--- a/src/main/java/br/com/academiadev/suicidesquad/repository/PetRepository.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/repository/PetRepository.java
@@ -1,10 +1,30 @@
 package br.com.academiadev.suicidesquad.repository;
 
 import br.com.academiadev.suicidesquad.entity.Pet;
+import br.com.academiadev.suicidesquad.entity.Usuario;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.querydsl.QuerydslPredicateExecutor;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 @Repository
 public interface PetRepository extends JpaRepository<Pet, Long>, QuerydslPredicateExecutor<Pet> {
+    // Encontra os pets de um usuário cujo registro de situação mais recente precede a data de corte,
+    // e que não foi notificado desde então (data do registro posterior à última notificação, ou nunca foi notificado)
+    @Query("SELECT p\n" +
+            "FROM Pet p\n" +
+            "JOIN Registro r1\n" +
+            "  ON r1.pet = p\n" +
+            "LEFT OUTER JOIN Registro r2\n" +
+            "  ON r1.pet = r2.pet\n" +
+            "  AND r1.data < r2.data\n" +
+            "WHERE r2.pet IS NULL\n" +
+            "  AND p.usuario = ?1\n" +
+            "  AND r1.data < ?2\n" +
+            "  AND (p.dataNotificacaoDeInatividade < r1.data\n" +
+            "       OR p.dataNotificacaoDeInatividade IS NULL)")
+    List<Pet> findPetsDoUsuarioInativosNaoNotificadosDesde(Usuario usuario, LocalDateTime dataDeCorte);
 }

--- a/src/main/java/br/com/academiadev/suicidesquad/service/PetService.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/service/PetService.java
@@ -11,6 +11,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 
 import javax.persistence.EntityManager;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -29,6 +30,12 @@ public class PetService {
 
     public List<Pet> findAll() {
         return petRepository.findAll();
+    }
+
+    public List<Pet> findPetsInativosNaoNotificadosDoUsuario(Usuario usuario) {
+        // Pet inativo: não houve atualização da situação por 7 dias.
+        LocalDateTime dataDeCorte = LocalDateTime.now().minusDays(7);
+        return petRepository.findPetsDoUsuarioInativosNaoNotificadosDesde(usuario, dataDeCorte);
     }
 
     public Optional<Pet> findById(Long idPet) {

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -9,16 +9,16 @@ INSERT INTO LOCALIZACAO (BAIRRO, CIDADE, UF) VALUES
 ('Santa Maria', 'Aracaju', 'Sergipe');
 
 INSERT INTO USUARIO (CREATED_DATE, LAST_MODIFIED_DATE, DATA_NASCIMENTO, EMAIL, FACEBOOK_USER_ID, NOME, SENHA, SEXO, LOCALIZACAO_ID, EMAIL_PUBLICO) VALUES
-('2018-11-23 13:18:25', '2018-11-24 17:24:53', '1970-12-10', 'dchristophle0@example.com', null, 'Danny Christophle', '$2a$10$YIqp1w.m/4brTM9vfXyuc.qCB/e4UkF8WMUh9b2ySspSXzCZMlZLS', 1, 1, 1),
-('2018-11-18 03:33:23', '2018-11-18 06:33:23', '1988-10-12', 'gnusche1@example.com', null, 'Gualterio Nusche', '$2a$10$2tTVuJQAyEhyy77MHniEGOEyJQave6ezht17Q8AOU5QPZqvtoul5e', 1, 2, 1),
-('2018-11-26 05:31:25', '2018-11-26 14:58:10', null, 'dwortt2@example.com', null, 'Dennie Wortt', '$2a$10$bC0R9ksjYhd//5m10ciPluxpjOUT75bYa6ya/rZ1qiARaZGB.yinC', 3, 3, 0),
-('2018-10-13 06:12:17', '2018-11-16 06:44:07', '2008-11-05', 'sconnal3@example.com', null, 'Salomi Connal', '$2a$10$V4ej2VaXtDLgEM0dQ6Va3ucibkJ07T38.rcZ/Iz61c48MgRm0ODv6', 2, 4, 1),
-('2018-09-10 17:24:53', '2018-11-20 14:04:17', '2010-05-21', 'dpfleger4@example.com', null, 'Dulce Pfleger', '$2a$10$EK7Wd/5kTniJ0wFl01zkVuAU.Ja5yu9LvCd9/8SCwsG.5mr4Li2ou', 3, 5, 1),
-('2018-11-10 14:58:33', '2018-11-25 14:26:17', '1985-05-02', 'loakwood5@example.com', null, 'Lela Oakwood', '$2a$10$7zn19kqTV09C0e8shv8wBOmCrFQ2GMPyItBvvjniW3O8Enf30yING', 3, 6, 0),
-('2018-09-18 08:59:56', '2018-11-18 17:12:06', null, 'kjoye6@example.com', null, 'Kitti Joye', '$2a$10$NIv/3CWCh4t7RzEgbFeWT./hIEgFQEtmHKgz5YyXQKK0ezIpRwh9K', 3, 7, 1),
-('2018-10-16 17:04:14', '2018-11-16 19:37:22', '1995-12-29', 'egalliver7@example.com', null, 'Euphemia Galliver', '$2a$10$K33sDIo6WQ6gjWMwJddzL.xnmTHudr5.ckpG5Z29.80wLSJ7bJWim', 2, 8, 1),
-('2018-11-17 22:37:19', '2018-11-17 23:33:03', null, 'okira0@example.com', null, 'Onfroi Kira', '$2a$10$lI8FFVHeiVyCBEV3dQCmSOrHAOsJRYTDC23rcSVNDh3usclJCk54S', 3, null, 0),
-('2018-11-14 08:03:55', '2018-11-14 22:18:13', '2018-03-09', 'nhathwood1@example.com', null, 'Nicolle Hathwood', '$2a$10$Qm003NFCbAfG8B0sn.Y1luc3VbDtTCF/ktolGkYw3d.kNDZ5/y106', 1, null, 1);
+('2018-02-23 13:18:25', '2018-08-24 17:24:53', '1970-12-10', 'dchristophle0@example.com', null, 'Danny Christophle', '$2a$10$YIqp1w.m/4brTM9vfXyuc.qCB/e4UkF8WMUh9b2ySspSXzCZMlZLS', 1, 1, 1),
+('2018-02-18 03:33:23', '2018-08-18 06:33:23', '1988-10-12', 'gnusche1@example.com', null, 'Gualterio Nusche', '$2a$10$2tTVuJQAyEhyy77MHniEGOEyJQave6ezht17Q8AOU5QPZqvtoul5e', 1, 2, 1),
+('2018-02-26 05:31:25', '2018-09-26 14:58:10', null, 'dwortt2@example.com', null, 'Dennie Wortt', '$2a$10$bC0R9ksjYhd//5m10ciPluxpjOUT75bYa6ya/rZ1qiARaZGB.yinC', 3, 3, 0),
+('2018-02-13 06:12:17', '2018-07-16 06:44:07', '2008-11-05', 'sconnal3@example.com', null, 'Salomi Connal', '$2a$10$V4ej2VaXtDLgEM0dQ6Va3ucibkJ07T38.rcZ/Iz61c48MgRm0ODv6', 2, 4, 1),
+('2018-09-10 17:24:53', '2018-10-20 14:04:17', '2010-05-21', 'dpfleger4@example.com', null, 'Dulce Pfleger', '$2a$10$EK7Wd/5kTniJ0wFl01zkVuAU.Ja5yu9LvCd9/8SCwsG.5mr4Li2ou', 3, 5, 1),
+('2018-02-10 14:58:33', '2018-05-25 14:26:17', '1985-05-02', 'loakwood5@example.com', null, 'Lela Oakwood', '$2a$10$7zn19kqTV09C0e8shv8wBOmCrFQ2GMPyItBvvjniW3O8Enf30yING', 3, 6, 0),
+('2018-01-18 08:59:56', '2018-04-18 17:12:06', null, 'kjoye6@example.com', null, 'Kitti Joye', '$2a$10$NIv/3CWCh4t7RzEgbFeWT./hIEgFQEtmHKgz5YyXQKK0ezIpRwh9K', 3, 7, 1),
+('2018-01-16 17:04:14', '2018-05-16 19:37:22', '1995-12-29', 'egalliver7@example.com', null, 'Euphemia Galliver', '$2a$10$K33sDIo6WQ6gjWMwJddzL.xnmTHudr5.ckpG5Z29.80wLSJ7bJWim', 2, 8, 1),
+('2018-02-17 22:37:19', '2018-03-17 23:33:03', null, 'okira0@example.com', null, 'Onfroi Kira', '$2a$10$lI8FFVHeiVyCBEV3dQCmSOrHAOsJRYTDC23rcSVNDh3usclJCk54S', 3, null, 0),
+('2018-02-14 08:03:55', '2018-06-14 22:18:13', '2018-03-09', 'nhathwood1@example.com', null, 'Nicolle Hathwood', '$2a$10$Qm003NFCbAfG8B0sn.Y1luc3VbDtTCF/ktolGkYw3d.kNDZ5/y106', 1, null, 1);
 
 INSERT INTO PUBLIC.TELEFONE (NUMERO, IS_WHATSAPP, USUARIO_ID) VALUES
 ('(16) 92289-2031', false, 9),
@@ -66,37 +66,37 @@ INSERT INTO PUBLIC.TELEFONE (NUMERO, IS_WHATSAPP, USUARIO_ID) VALUES
 
 
 INSERT INTO PET (CREATED_DATE, LAST_MODIFIED_DATE, CASTRACAO, CATEGORIA, COMPRIMENTO_PELO, DESCRICAO, NOME, PORTE, RACA, SEXO, TIPO, VACINACAO, ID_LOCALIZACAO, ID_USUARIO) VALUES
-('2018-11-25 18:58:41', '2018-11-26 01:54:33', 1, 3, 4, 'Vivamus in felis eu sapien cursus vestibulum.', 'Arabelle', 1, 5, 3, 1, 1, null, 10),
-('2018-11-24 18:09:41', '2018-11-24 18:35:46', 1, 2, 1, 'Curabitur convallis. Duis consequat dui nec nisi volutpat eleifend.', 'Wolfy', 3, 4, 3, 1, 1, null, 10),
-('2018-11-24 02:45:47', '2018-11-24 18:07:05', 1, 3, 2, 'Fusce consequat. Nulla nisl. Nunc nisl.', 'Creighton', 1, 4, 3, 1, 1, 4, 10),
-('2018-11-23 06:49:59', '2018-11-24 08:11:06', 1, 2, 1, 'Proin eu mi. Nulla ac enim. In tempor, turpis nec euismod scelerisque, quam turpis adipiscing lorem, vitae mattis nibh ligula nec sem.', null, 2, 5, 3, 1, 1, null, 9),
-('2018-11-23 20:33:38', '2018-11-24 02:38:02', 1, 3, 3, null, null, 2, 4, 3, 1, 1, null, 2),
-('2018-11-23 19:24:58', '2018-11-24 05:52:45', 1, 3, 1, 'Vestibulum rutrum rutrum neque. Aenean auctor gravida sem. Praesent id massa id nisl venenatis lacinia.', 'Isidro', 3, 7, 3, 2, 1, null, 5),
-('2018-11-23 03:47:14', '2018-11-23 21:31:59', 1, 1, 1, 'Pellentesque viverra pede ac diam.', 'Julee', 1, 6, 3, 2, 1, null, 9),
-('2018-11-23 20:08:20', '2018-11-24 03:06:22', 1, 2, 3, 'Morbi sem mauris, laoreet ut, rhoncus aliquet, pulvinar sed, nisl.', 'Merridie', 1, 7, 3, 2, 1, 3, 8),
-('2018-11-26 13:23:29', '2018-11-26 13:49:13', 1, 3, 4, null, 'Itch', 3, 7, 3, 2, 1, 2, 9),
-('2018-11-23 01:04:15', '2018-11-23 11:53:37', 1, 1, 2, 'Phasellus sit amet erat. Nulla tempus. Vivamus in felis eu sapien cursus vestibulum.', null, 1, 8, 3, 3, 1, null, 4),
-('2018-11-26 12:37:41', '2018-11-27 06:58:54', 1, 2, 4, 'Ut at dolor quis odio consequat varius.', 'Julee', 3, 9, 3, 3, 1, null, 2);
+('2018-10-25 18:58:41', '2018-10-26 01:54:33', 1, 3, 4, 'Vivamus in felis eu sapien cursus vestibulum.', 'Arabelle', 1, 5, 3, 1, 1, null, 10),
+('2018-10-24 18:09:41', '2018-10-24 18:35:46', 1, 2, 1, 'Curabitur convallis. Duis consequat dui nec nisi volutpat eleifend.', 'Wolfy', 3, 4, 3, 1, 1, null, 10),
+('2018-10-24 02:45:47', '2018-10-24 18:07:05', 1, 3, 2, 'Fusce consequat. Nulla nisl. Nunc nisl.', 'Creighton', 1, 4, 3, 1, 1, 4, 10),
+('2018-10-23 06:49:59', '2018-10-24 08:11:06', 1, 2, 1, 'Proin eu mi. Nulla ac enim. In tempor, turpis nec euismod scelerisque, quam turpis adipiscing lorem, vitae mattis nibh ligula nec sem.', null, 2, 5, 3, 1, 1, null, 9),
+('2018-10-23 20:33:38', '2018-10-24 02:38:02', 1, 3, 3, null, null, 2, 4, 3, 1, 1, null, 2),
+('2018-10-23 19:24:58', '2018-10-24 05:52:45', 1, 3, 1, 'Vestibulum rutrum rutrum neque. Aenean auctor gravida sem. Praesent id massa id nisl venenatis lacinia.', 'Isidro', 3, 7, 3, 2, 1, null, 5),
+('2018-10-23 03:47:14', '2018-10-23 21:31:59', 1, 1, 1, 'Pellentesque viverra pede ac diam.', 'Julee', 1, 6, 3, 2, 1, null, 9),
+('2018-10-23 20:08:20', '2018-10-24 03:06:22', 1, 2, 3, 'Morbi sem mauris, laoreet ut, rhoncus aliquet, pulvinar sed, nisl.', 'Merridie', 1, 7, 3, 2, 1, 3, 8),
+('2018-10-26 13:23:29', '2018-10-26 13:49:13', 1, 3, 4, null, 'Itch', 3, 7, 3, 2, 1, 2, 9),
+('2018-10-23 01:04:15', '2018-10-23 11:53:37', 1, 1, 2, 'Phasellus sit amet erat. Nulla tempus. Vivamus in felis eu sapien cursus vestibulum.', null, 1, 8, 3, 3, 1, null, 4),
+('2018-10-26 12:37:41', '2018-10-27 06:58:54', 1, 2, 4, 'Ut at dolor quis odio consequat varius.', 'Julee', 3, 9, 3, 3, 1, null, 2);
 
 INSERT INTO REGISTRO (ID_PET, DATA, SITUACAO) VALUES
-(1, '2018-12-05 21:26:12', 1),
-(1, '2018-12-06 16:17:45', 2),
-(1, '2018-12-12 08:38:15', 3),
-(9, '2018-12-06 05:08:41', 1),
-(9, '2018-12-06 19:14:12', 2),
-(9, '2018-12-10 16:21:59', 3),
-(10, '2018-12-07 13:51:43', 1),
-(10, '2018-12-08 13:44:54', 2),
-(10, '2018-12-12 22:08:31', 3),
-(7, '2018-12-10 18:29:26', 1),
-(7, '2018-12-11 05:33:40', 2),
-(7, '2018-12-16 09:30:47', 3),
+(1, '2018-12-02 08:38:15', 1),
+(1, '2018-12-03 16:17:45', 2),
+(1, '2018-12-03 21:26:12', 3),
+(9, '2018-12-04 05:08:41', 1),
+(9, '2018-12-04 09:14:12', 2),
+(9, '2018-12-04 14:21:59', 3),
+(10, '2018-12-02 22:08:31', 1),
+(10, '2018-12-04 13:44:54', 2),
+(10, '2018-12-04 13:51:43', 3),
+(7, '2018-12-01 05:33:40', 1),
+(7, '2018-12-01 18:29:26', 2),
+(7, '2018-12-04 09:30:47', 3),
 (6, '2018-11-30 10:04:11', 1),
 (6, '2018-12-01 12:56:46', 2),
 (8, '2018-12-03 11:05:50', 1),
 (8, '2018-12-04 11:10:45', 2),
 (5, '2018-11-30 00:30:53', 1),
 (5, '2018-11-30 22:09:43', 2),
-(2, '2018-12-10 22:59:51', 1),
+(2, '2018-12-01 22:59:51', 1),
 (3, '2018-12-02 23:32:35', 1),
-(4, '2018-12-08 03:35:50', 1);
+(4, '2018-12-04 03:35:50', 1);

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -65,18 +65,18 @@ INSERT INTO PUBLIC.TELEFONE (NUMERO, IS_WHATSAPP, USUARIO_ID) VALUES
 ('(50) 92794-1789', false, 10);
 
 
-INSERT INTO PET (CREATED_DATE, LAST_MODIFIED_DATE, CASTRACAO, CATEGORIA, COMPRIMENTO_PELO, DESCRICAO, NOME, PORTE, RACA, SEXO, TIPO, VACINACAO, ID_LOCALIZACAO, ID_USUARIO) VALUES
-('2018-10-25 18:58:41', '2018-10-26 01:54:33', 1, 3, 4, 'Vivamus in felis eu sapien cursus vestibulum.', 'Arabelle', 1, 5, 3, 1, 1, null, 10),
-('2018-10-24 18:09:41', '2018-10-24 18:35:46', 1, 2, 1, 'Curabitur convallis. Duis consequat dui nec nisi volutpat eleifend.', 'Wolfy', 3, 4, 3, 1, 1, null, 10),
-('2018-10-24 02:45:47', '2018-10-24 18:07:05', 1, 3, 2, 'Fusce consequat. Nulla nisl. Nunc nisl.', 'Creighton', 1, 4, 3, 1, 1, 4, 10),
-('2018-10-23 06:49:59', '2018-10-24 08:11:06', 1, 2, 1, 'Proin eu mi. Nulla ac enim. In tempor, turpis nec euismod scelerisque, quam turpis adipiscing lorem, vitae mattis nibh ligula nec sem.', null, 2, 5, 3, 1, 1, null, 9),
-('2018-10-23 20:33:38', '2018-10-24 02:38:02', 1, 3, 3, null, null, 2, 4, 3, 1, 1, null, 2),
-('2018-10-23 19:24:58', '2018-10-24 05:52:45', 1, 3, 1, 'Vestibulum rutrum rutrum neque. Aenean auctor gravida sem. Praesent id massa id nisl venenatis lacinia.', 'Isidro', 3, 7, 3, 2, 1, null, 5),
-('2018-10-23 03:47:14', '2018-10-23 21:31:59', 1, 1, 1, 'Pellentesque viverra pede ac diam.', 'Julee', 1, 6, 3, 2, 1, null, 9),
-('2018-10-23 20:08:20', '2018-10-24 03:06:22', 1, 2, 3, 'Morbi sem mauris, laoreet ut, rhoncus aliquet, pulvinar sed, nisl.', 'Merridie', 1, 7, 3, 2, 1, 3, 8),
-('2018-10-26 13:23:29', '2018-10-26 13:49:13', 1, 3, 4, null, 'Itch', 3, 7, 3, 2, 1, 2, 9),
-('2018-10-23 01:04:15', '2018-10-23 11:53:37', 1, 1, 2, 'Phasellus sit amet erat. Nulla tempus. Vivamus in felis eu sapien cursus vestibulum.', null, 1, 8, 3, 3, 1, null, 4),
-('2018-10-26 12:37:41', '2018-10-27 06:58:54', 1, 2, 4, 'Ut at dolor quis odio consequat varius.', 'Julee', 3, 9, 3, 3, 1, null, 2);
+INSERT INTO PET (CREATED_DATE, LAST_MODIFIED_DATE, CASTRACAO, CATEGORIA, COMPRIMENTO_PELO, DESCRICAO, NOME, PORTE, RACA, SEXO, TIPO, VACINACAO, DATA_NOTIFICACAO_DE_INATIVIDADE, ID_LOCALIZACAO, ID_USUARIO) VALUES
+('2018-10-25 18:58:41', '2018-10-26 01:54:33', 1, 3, 4, 'Vivamus in felis eu sapien cursus vestibulum.', 'Arabelle', 1, 5, 3, 1, 1, null, null, 10),
+('2018-10-24 18:09:41', '2018-10-24 18:35:46', 1, 2, 1, 'Curabitur convallis. Duis consequat dui nec nisi volutpat eleifend.', 'Wolfy', 3, 4, 3, 1, 1, null, null, 10),
+('2018-10-24 02:45:47', '2018-10-24 18:07:05', 1, 3, 2, 'Fusce consequat. Nulla nisl. Nunc nisl.', 'Creighton', 1, 4, 3, 1, 1, null, 4, 10),
+('2018-10-23 06:49:59', '2018-10-24 08:11:06', 1, 2, 1, 'Proin eu mi. Nulla ac enim. In tempor, turpis nec euismod scelerisque, quam turpis adipiscing lorem, vitae mattis nibh ligula nec sem.', null, 2, 5, 3, 1, 1, null, null, 9),
+('2018-10-23 20:33:38', '2018-10-24 02:38:02', 1, 3, 3, null, null, 2, 4, 3, 1, 1, null, null, 2),
+('2018-10-23 19:24:58', '2018-10-24 05:52:45', 1, 3, 1, 'Vestibulum rutrum rutrum neque. Aenean auctor gravida sem. Praesent id massa id nisl venenatis lacinia.', 'Isidro', 3, 7, 3, 2, 1, null, null, 5),
+('2018-10-23 03:47:14', '2018-10-23 21:31:59', 1, 1, 1, 'Pellentesque viverra pede ac diam.', 'Julee', 1, 6, 3, 2, 1, null, null, 9),
+('2018-10-23 20:08:20', '2018-10-24 03:06:22', 1, 2, 3, 'Morbi sem mauris, laoreet ut, rhoncus aliquet, pulvinar sed, nisl.', 'Merridie', 1, 7, 3, 2, 1, null, 3, 8),
+('2018-10-26 13:23:29', '2018-10-26 13:49:13', 1, 3, 4, null, 'Itch', 3, 7, 3, 2, 1, null, 2, 9),
+('2018-10-23 01:04:15', '2018-10-23 11:53:37', 1, 1, 2, 'Phasellus sit amet erat. Nulla tempus. Vivamus in felis eu sapien cursus vestibulum.', null, 1, 8, 3, 3, 1, null, null, 4),
+('2018-10-26 12:37:41', '2018-10-27 06:58:54', 1, 2, 4, 'Ut at dolor quis odio consequat varius.', 'Julee', 3, 9, 3, 3, 1, null, null, 2);
 
 INSERT INTO REGISTRO (ID_PET, DATA, SITUACAO) VALUES
 (1, '2018-12-02 08:38:15', 1),


### PR DESCRIPTION
Closes #42

# O que foi feito

* Habilitada a função de agendamento de tarefas do Spring com `@EnableScheduling`, para enviar os emails uma vez por dia.
* Adicionada consulta de pets inativos, com base na data do último registro de situação do pet.
* Campo `dataNotificaoDeInatividade` adicionado ao pet, para não enviar emails repetidos.
* Dados de teste (`data.sql`) atualizados.
* Adicionado o componente `PetMonitor`, que faz a consulta dos pets inativos e envia um email para o usuário publicador.

Pets inativos são aqueles que não tiveram mudança de situação por sete dias. Após o envio do primeiro email de notificação de um pet, este pet não provocará um outro envio até que haja atividade novamente (devido ao campo `dataNotificaoDeInatividade`).

# Por que foi feito

Para aumentar a taxa de retenção de usuários (teoricamente).

# O que falta fazer

Colocar links pro frontend no email.