### PR TITLE
Cadastro com Facebook sem email

### DIFF
--- a/src/main/java/br/com/academiadev/suicidesquad/config/SecurityConfig.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/config/SecurityConfig.java
@@ -49,7 +49,9 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
             .authorizeRequests()
                 .antMatchers(
                     "/auth/facebook/authorization",
-                    "/auth/facebook/callback",
+                    "/auth/facebook/cadastrar_e_logar_via_callback",
+                    "/auth/facebook/cadastrar_e_logar_com_email_suplementar",
+                    "/auth/facebook/logar_com_access_token",
                     "/auth/email"
                 ).permitAll()
                 .antMatchers(

--- a/src/main/java/br/com/academiadev/suicidesquad/controller/FacebookAuthController.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/controller/FacebookAuthController.java
@@ -1,21 +1,28 @@
 package br.com.academiadev.suicidesquad.controller;
 
+import br.com.academiadev.suicidesquad.dto.UsuarioFacebookCreateDTO;
+import br.com.academiadev.suicidesquad.dto.UsuarioFacebookLoginDTO;
 import br.com.academiadev.suicidesquad.entity.Usuario;
+import br.com.academiadev.suicidesquad.exception.EmailExistenteException;
+import br.com.academiadev.suicidesquad.exception.InvalidAccessTokenException;
+import br.com.academiadev.suicidesquad.exception.UsuarioExistenteException;
 import br.com.academiadev.suicidesquad.security.JwtTokenProvider;
 import br.com.academiadev.suicidesquad.service.FacebookService;
 import br.com.academiadev.suicidesquad.service.UsuarioService;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.social.facebook.api.User;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.util.UriComponentsBuilder;
 
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletResponse;
+import javax.validation.Valid;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Optional;
@@ -23,13 +30,12 @@ import java.util.Optional;
 @RestController
 @ConditionalOnProperty(prefix = "app.social.facebook", name = "enabled")
 @RequestMapping("/auth/facebook")
+@Api(value = "Autenticação por meio do Facebook")
 public class FacebookAuthController {
 
     private final FacebookService facebookService;
 
     private final UsuarioService usuarioService;
-
-    private final AuthenticationManager authenticationManager;
 
     private final JwtTokenProvider jwtTokenProvider;
 
@@ -37,38 +43,129 @@ public class FacebookAuthController {
     private String frontendRedirectUri;
 
     @Autowired
-    public FacebookAuthController(FacebookService facebookService, UsuarioService usuarioService, AuthenticationManager authenticationManager, JwtTokenProvider jwtTokenProvider) {
+    public FacebookAuthController(FacebookService facebookService, UsuarioService usuarioService, JwtTokenProvider jwtTokenProvider) {
         this.facebookService = facebookService;
         this.usuarioService = usuarioService;
-        this.authenticationManager = authenticationManager;
         this.jwtTokenProvider = jwtTokenProvider;
     }
 
     @GetMapping("/authorization")
+    @ApiOperation(
+            value = "Redireciona para a URL de autorização do Facebook",
+            notes = "Inicia a autenticação com um perfil do Facebook, através de um redirecionamento que requisitará " +
+                    "as permissões para acessar as informações do perfil do usuário, e retornará um código por meio " +
+                    "do endpoint de callback."
+    )
+    @ApiResponses({
+            @ApiResponse(code = 302, message = "Redirecionamento com o cookie do token de sessão"),
+            @ApiResponse(code = 302, message = "Redirecionamento sem nada (falha na autenticação"),
+    })
     public void getFacebookAuthorization(HttpServletResponse response) throws IOException {
         response.sendRedirect(facebookService.createAuthorizationURL());
     }
 
-    @GetMapping("/callback")
-    public void facebookCallback(HttpServletResponse response, @RequestParam("code") String code) throws IOException {
-        Optional<User> facebookUser = facebookService.getAccessToken(code).flatMap(facebookService::getUser);
+    private Cookie buildTokenCookie(String email) {
+        String token = jwtTokenProvider.getToken(email, Collections.emptyList());
+        Cookie tokenCookie = new Cookie("token", token);
+        tokenCookie.setPath("/");
+        tokenCookie.setDomain("localhost");
+        return tokenCookie;
+    }
 
-        if (facebookUser.isPresent()) {
-            Usuario usuario = facebookService.buildUsuarioFromFacebookUser(facebookUser.get());
-            final String email = usuario.getEmail();
-            if (email == null) {
-                // TODO: Tratar quando o usuário não tem email
-            }
+    @GetMapping("/cadastrar_e_logar_via_callback")
+    @ApiOperation(
+            value = "Cadastrar e logar via callback",
+            notes = "Cadastra um usuário e inicia uma sessão através do código devolvido pelo Facebook. " +
+                    "Quando o usuário tem o email públicamente compartilhado no Facebook, esta etapa é " +
+                    "suficiente para autenticar o usuário."
+    )
+    @ApiResponses({
+            @ApiResponse(code = 302, message = "Redirecionamento com o cookie do token de sessão"),
+            @ApiResponse(code = 302, message = "Redirecionamento sem o cookie, mas com um access token"),
+            @ApiResponse(code = 302, message = "Redirecionamento sem nada (falha na autenticação)"),
+    })
+    public void cadastrarViaCallback(HttpServletResponse response, @RequestParam("code") String code) throws IOException {
+        Optional<String> accessToken = facebookService.getAccessToken(code);
+        Optional<User> facebookUser = accessToken.flatMap(facebookService::getUser);
 
-            String token = jwtTokenProvider.getToken(email, Collections.emptyList());
-            Cookie tokenCookie = new Cookie("token", token);
-            tokenCookie.setPath("/");
-            tokenCookie.setDomain("localhost");
-            response.addCookie(tokenCookie);
-            usuarioService.save(usuario);
+        if (!facebookUser.isPresent()) {
+            // Falha no login
+            // Retorna para o frontend sem token de sessão
+            response.sendRedirect(frontendRedirectUri);
+            return;
         }
 
+        Usuario usuario = facebookService.buildUsuarioFromFacebookUser(facebookUser.get());
+
+        if (usuario.getEmail() == null) {
+            // Conta do facebook sem email cadastrado/público
+            // O frontend deve pedir um email e fazer outro request
+            // no endpoint "cadastrarComEmailSuplementar",
+            // usando o accessToken retornado na query string deste redirect.
+            response.sendRedirect(UriComponentsBuilder
+                    .fromHttpUrl(frontendRedirectUri)
+                    .queryParam("accessToken", accessToken.get())
+                    .build()
+                    .toUriString());
+            return;
+        }
+
+        Cookie tokenCookie = buildTokenCookie(usuario.getEmail());
+        response.addCookie(tokenCookie);
         response.sendRedirect(frontendRedirectUri);
     }
 
+    @PostMapping("/cadastrar_e_logar_com_email_suplementar")
+    @ApiOperation(
+            value = "Cadastrar e logar com email suplementar",
+            notes = "Cadastra um usuário e inicia uma sessão através de um access token e um email suplementar. " +
+                    "Usado quando o usuário não compartilhou o email na autenticação. O access token é retornado no " +
+                    "redirecionamento do callback."
+    )
+    @ApiResponses({
+            @ApiResponse(code = 200, message = "Retorna cookie com o token de sessão"),
+            @ApiResponse(code = 400, message = "Usuário já cadastrado"),
+            @ApiResponse(code = 400, message = "Email já usado"),
+            @ApiResponse(code = 400, message = "Access token inválido"),
+    })
+    public void cadastrarComEmailSuplementar(HttpServletResponse response, @Valid @RequestBody UsuarioFacebookCreateDTO dto) {
+        User facebookUser = facebookService.getUser(dto.getAccess_token())
+                .orElseThrow(InvalidAccessTokenException::new);
+
+        if (usuarioService.existsByFacebookUserId(facebookUser.getId())) {
+            // Usuário já cadastrado
+            throw new UsuarioExistenteException();
+        }
+
+        String emailSuplementar = dto.getEmail_suplementar();
+        if (usuarioService.existsByEmail(emailSuplementar)) {
+            // Email já usado
+            throw new EmailExistenteException();
+        }
+
+        Usuario usuario = facebookService.buildUsuarioFromFacebookUser(facebookUser);
+        usuario.setEmail(emailSuplementar);
+        usuarioService.save(usuario);
+
+        final Cookie tokenCookie = buildTokenCookie(usuario.getEmail());
+        response.addCookie(tokenCookie);
+    }
+
+    @PostMapping("/logar_com_access_token")
+    @ApiOperation(
+            value = "Logar com access token",
+            notes = "Inicia uma acessão através de um access token."
+    )
+    @ApiResponses({
+            @ApiResponse(code = 200, message = "Retorna cookie com o token de sessão"),
+            @ApiResponse(code = 400, message = "Token inválido")
+    })
+    public void loginComAccessToken(HttpServletResponse response, @Valid @RequestBody UsuarioFacebookLoginDTO dto) {
+        Usuario usuario = facebookService.getUser(dto.getAccess_token())
+                .flatMap(user -> usuarioService.findByFacebookUserId(user.getId()))
+                .orElseThrow(InvalidAccessTokenException::new);
+
+        Cookie tokenCookie = buildTokenCookie(usuario.getEmail());
+        response.addCookie(tokenCookie);
+    }
 }

--- a/src/main/java/br/com/academiadev/suicidesquad/dto/UsuarioFacebookCreateDTO.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/dto/UsuarioFacebookCreateDTO.java
@@ -1,0 +1,16 @@
+package br.com.academiadev.suicidesquad.dto;
+
+import lombok.Data;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotNull;
+
+@Data
+public class UsuarioFacebookCreateDTO {
+    @NotNull
+    private String access_token;
+
+    @NotNull
+    @Email
+    private String email_suplementar;
+}

--- a/src/main/java/br/com/academiadev/suicidesquad/dto/UsuarioFacebookLoginDTO.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/dto/UsuarioFacebookLoginDTO.java
@@ -1,0 +1,11 @@
+package br.com.academiadev.suicidesquad.dto;
+
+import lombok.Data;
+
+import javax.validation.constraints.NotNull;
+
+@Data
+public class UsuarioFacebookLoginDTO {
+    @NotNull
+    private String access_token;
+}

--- a/src/main/java/br/com/academiadev/suicidesquad/exception/InvalidAccessTokenException.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/exception/InvalidAccessTokenException.java
@@ -1,0 +1,4 @@
+package br.com.academiadev.suicidesquad.exception;
+
+public class InvalidAccessTokenException extends InvalidTokenException {
+}

--- a/src/main/java/br/com/academiadev/suicidesquad/exception/UsuarioExistenteException.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/exception/UsuarioExistenteException.java
@@ -1,0 +1,4 @@
+package br.com.academiadev.suicidesquad.exception;
+
+public class UsuarioExistenteException extends APIException {
+}

--- a/src/main/java/br/com/academiadev/suicidesquad/exception/handler/RestResponseEntityExceptionHandler.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/exception/handler/RestResponseEntityExceptionHandler.java
@@ -3,6 +3,7 @@ package br.com.academiadev.suicidesquad.exception.handler;
 import br.com.academiadev.suicidesquad.exception.EmailExistenteException;
 import br.com.academiadev.suicidesquad.exception.InvalidTokenException;
 import br.com.academiadev.suicidesquad.exception.ResourceNotFoundException;
+import br.com.academiadev.suicidesquad.exception.UsuarioExistenteException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -66,6 +67,18 @@ public class RestResponseEntityExceptionHandler extends ResponseEntityExceptionH
         final ObjectNode errorNode = objectMapper.createObjectNode();
         errorNode.put("code", 400);
         errorNode.put("error", "Este email já foi usado. Por favor, use outro endereço.");
+        final HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON_UTF8);
+        return handleExceptionInternal(e, objectMapper.writeValueAsString(errorNode), headers, HttpStatus.BAD_REQUEST, request);
+    }
+
+    @ExceptionHandler({
+            UsuarioExistenteException.class
+    })
+    private ResponseEntity<Object> handleUsuarioExistente(UsuarioExistenteException e, WebRequest request) throws JsonProcessingException {
+        final ObjectNode errorNode = objectMapper.createObjectNode();
+        errorNode.put("code", 400);
+        errorNode.put("error", "Este usuário já foi cadastrado.");
         final HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON_UTF8);
         return handleExceptionInternal(e, objectMapper.writeValueAsString(errorNode), headers, HttpStatus.BAD_REQUEST, request);

--- a/src/main/java/br/com/academiadev/suicidesquad/repository/UsuarioRepository.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/repository/UsuarioRepository.java
@@ -12,4 +12,5 @@ public interface UsuarioRepository extends JpaRepository<Usuario, Long> {
     Optional<Usuario> findByEmail(String email);
     Optional<Usuario> findByFacebookUserId(String facebookUserId);
     boolean existsByEmail(String email);
+    boolean existsByFacebookUserId(String facebookUserId);
 }

--- a/src/main/java/br/com/academiadev/suicidesquad/service/UsuarioService.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/service/UsuarioService.java
@@ -24,7 +24,6 @@ public class UsuarioService {
     public Optional<Usuario> findByEmail(String email) {
         return usuarioRepository.findByEmail(email);
     }
-
     public List<Usuario> findAll() {
         return usuarioRepository.findAll();
     }
@@ -47,6 +46,10 @@ public class UsuarioService {
 
     public boolean existsByEmail(String email) {
         return usuarioRepository.existsByEmail(email);
+    }
+
+    public boolean existsByFacebookUserId(String facebookUserId) {
+        return usuarioRepository.existsByFacebookUserId(facebookUserId);
     }
 
     public void deleteById(Long idUsuario) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,7 +2,7 @@ spring.profiles.active=dev
 spring.datasource.url=jdbc:h2:~/test;AUTO_SERVER=TRUE
 
 app.social.facebook.enabled = false
-app.social.facebook.backend-redirect-uri=http://localhost:8080/auth/facebook/callback
+app.social.facebook.backend-redirect-uri=http://localhost:8080/auth/facebook/cadastrar_e_logar_via_callback
 app.social.facebook.frontend-redirect-uri=http://localhost:8081/
 
 app.email.sender.domain=404pets.com

--- a/src/test/java/br/com/academiadev/suicidesquad/controller/FacebookAuthControllerTest.java
+++ b/src/test/java/br/com/academiadev/suicidesquad/controller/FacebookAuthControllerTest.java
@@ -72,7 +72,7 @@ public class FacebookAuthControllerTest {
         mvc.perform(get("/auth/facebook/cadastrar_e_logar_via_callback")
                 .param("code", facebookCode))
                 .andExpect(status().isFound())
-                .andExpect(redirectedUrl("http://example.com/"))
+                .andExpect(redirectedUrl("http://example.com/?accessToken=" + facebookAccessToken ))
                 .andExpect(cookie().exists("token"));
     }
 

--- a/src/test/java/br/com/academiadev/suicidesquad/controller/FacebookAuthControllerTest.java
+++ b/src/test/java/br/com/academiadev/suicidesquad/controller/FacebookAuthControllerTest.java
@@ -1,0 +1,197 @@
+package br.com.academiadev.suicidesquad.controller;
+
+import br.com.academiadev.suicidesquad.entity.Usuario;
+import br.com.academiadev.suicidesquad.service.FacebookService;
+import br.com.academiadev.suicidesquad.service.UsuarioService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.social.facebook.api.User;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(properties = {
+        "app.social.facebook.enabled=true",
+        "app.social.facebook.frontend-redirect-uri=http://example.com/"
+})
+@AutoConfigureMockMvc
+@Transactional
+public class FacebookAuthControllerTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Autowired
+    private UsuarioService usuarioService;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @MockBean
+    private FacebookService facebookService;
+
+    @Test
+    public void getFacebookAuthorization() throws Exception {
+        final String authorizationURL = "http://example.com/authorize?app=blah";
+        when(facebookService.createAuthorizationURL()).thenReturn(authorizationURL);
+
+        mvc.perform(get("/auth/facebook/authorization"))
+                .andExpect(status().isFound())
+                .andExpect(redirectedUrl(authorizationURL));
+    }
+
+    @Test
+    public void cadastrarViaCallback_quandoValidoComEmail_entaoRedirectionaComTokenSessao() throws Exception {
+        final String facebookCode = "i'm a legit code. it's true!";
+        final String facebookAccessToken = "i'm a valid access token, believe me folks.";
+        final User facebookUser = mock(User.class);
+        final Usuario usuario = mock(Usuario.class);
+        when(facebookService.getAccessToken(facebookCode)).thenReturn(Optional.of(facebookAccessToken));
+        when(facebookService.getUser(facebookAccessToken)).thenReturn(Optional.of(facebookUser));
+        when(facebookService.buildUsuarioFromFacebookUser(facebookUser)).thenReturn(usuario);
+        when(usuario.getEmail()).thenReturn("fulano@example.com");
+
+        mvc.perform(get("/auth/facebook/cadastrar_e_logar_via_callback")
+                .param("code", facebookCode))
+                .andExpect(status().isFound())
+                .andExpect(redirectedUrl("http://example.com/"))
+                .andExpect(cookie().exists("token"));
+    }
+
+    @Test
+    public void cadastrarViaCallback_quandoValidoSemEmail_entaoRedirecionaComAccessToken() throws Exception {
+        final String facebookCode = "i'm a legit code. it's true!";
+        final String facebookAccessToken = "i'm a valid access token, believe me folks.";
+        final User facebookUser = mock(User.class);
+        final Usuario usuario = mock(Usuario.class);
+        when(facebookService.getAccessToken(facebookCode)).thenReturn(Optional.of(facebookAccessToken));
+        when(facebookService.getUser(facebookAccessToken)).thenReturn(Optional.of(facebookUser));
+        when(facebookService.buildUsuarioFromFacebookUser(facebookUser)).thenReturn(usuario);
+        when(usuario.getEmail()).thenReturn(null);
+
+        mvc.perform(get("/auth/facebook/cadastrar_e_logar_via_callback")
+                .param("code", facebookCode))
+                .andExpect(status().isFound())
+                .andExpect(redirectedUrl("http://example.com/?accessToken=" + facebookAccessToken))
+                .andExpect(cookie().doesNotExist("token"));
+    }
+
+    @Test
+    public void cadastrarViaCallback_quandoInvalido_entaoRedirecionaSemTokenSessao() throws Exception {
+        final String facebookCode = "i'm an invalid code. try me!";
+        when(facebookService.getAccessToken(facebookCode)).thenReturn(Optional.empty());
+
+        mvc.perform(get("/auth/facebook/cadastrar_e_logar_via_callback")
+                .param("code", facebookCode))
+                .andExpect(status().isFound())
+                .andExpect(redirectedUrl("http://example.com/"))
+                .andExpect(cookie().doesNotExist("token"));
+    }
+
+    @Test
+    public void cadastrarComEmailSuplementar_quandoValido_entaoCadastraERetornaTokenSessao() throws Exception {
+        final String facebookAccessToken = "i'm a valid access token, believe me folks.";
+        final User facebookUser = mock(User.class);
+        final Usuario usuario = Usuario.builder().nome("Fulano").build();
+        when(facebookService.getUser(facebookAccessToken)).thenReturn(Optional.of(facebookUser));
+        when(facebookService.buildUsuarioFromFacebookUser(facebookUser)).thenReturn(usuario);
+
+        String emailSuplementar = "fulano@example.com";
+
+        ObjectNode dto = objectMapper.createObjectNode();
+        dto.put("access_token", facebookAccessToken);
+        dto.put("email_suplementar", emailSuplementar);
+
+        mvc.perform(post("/auth/facebook/cadastrar_e_logar_com_email_suplementar")
+                .content(objectMapper.writeValueAsString(dto))
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(cookie().exists("token"));
+
+        assertThat(usuarioService.existsByEmail(emailSuplementar), equalTo(true));
+    }
+
+    @Test
+    public void cadastrarComEmailSuplementar_quandoUsuarioExistente_entaoRetornaErro() throws Exception {
+        final String facebookAccessToken = "i'm a valid access token, believe me folks.";
+        String facebookUserId = "123";
+
+        final User facebookUser = mock(User.class);
+        when(facebookUser.getId()).thenReturn(facebookUserId);
+        when(facebookService.getUser(facebookAccessToken)).thenReturn(Optional.of(facebookUser));
+
+        usuarioService.save(Usuario.builder()
+                .nome("Fulano A")
+                .email("fulano.a@example.com")
+                .facebookUserId(facebookUserId)
+                .build());
+
+        ObjectNode dto = objectMapper.createObjectNode();
+        dto.put("access_token", facebookAccessToken);
+        dto.put("email_suplementar", "fulano.b@example.com");
+
+        mvc.perform(post("/auth/facebook/cadastrar_e_logar_com_email_suplementar")
+                .content(objectMapper.writeValueAsString(dto))
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(cookie().doesNotExist("token"));
+    }
+
+    @Test
+    public void loginComAccessToken_quandoValido_entaoRetornaTokenSessao() throws Exception {
+        final String facebookAccessToken = "i'm a valid access token, believe me folks.";
+        String facebookUserId = "123";
+
+        final User facebookUser = mock(User.class);
+        when(facebookUser.getId()).thenReturn(facebookUserId);
+        when(facebookService.getUser(facebookAccessToken)).thenReturn(Optional.of(facebookUser));
+
+        usuarioService.save(Usuario.builder()
+                .email("fulano@example.com")
+                .facebookUserId(facebookUserId)
+                .nome("Fulano")
+                .build());
+
+        ObjectNode dto = objectMapper.createObjectNode();
+        dto.put("access_token", facebookAccessToken);
+
+        mvc.perform(post("/auth/facebook/logar_com_access_token")
+                .content(objectMapper.writeValueAsString(dto))
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(cookie().exists("token"));
+    }
+
+    @Test
+    public void loginComAccessToken_quandoInvalido_entaoRetornaErro() throws Exception {
+        final String facebookAccessToken = "i'm a valid access token, believe me folks.";
+        when(facebookService.getUser(facebookAccessToken)).thenReturn(Optional.empty());
+
+        ObjectNode dto = objectMapper.createObjectNode();
+        dto.put("access_token", facebookAccessToken);
+
+        mvc.perform(post("/auth/facebook/logar_com_access_token")
+                .content(objectMapper.writeValueAsString(dto))
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(cookie().doesNotExist("token"));
+    }
+}


### PR DESCRIPTION
Closes #57

# O que foi feito

* URLs do `FacebookAuthController` alteradas para ficarem mais evidentes
* Adicionadas anotações do Swagger ao `FacebookAuthController`
* Adicionado o endpoint "Cadastrar e logar com email suplementar", que trata o caso de o Facebook não retornar um endereço de email
* Adicionado o endpoint "Logar com access token", que agiliza o processo de login, eliminando o redirecionamento para o Facebook após o primeiro cadastro. Basta o frontend guardar este access token, que é válido até 60 dias.
* Adicionada a `UsuarioExistenteException`, lançado para evitar que um usuário mude o seu email através do endpoint de cadastro por email suplementar.
* Adicionada a `InvalidAccessTokenException`, para retornar quando o token está inválido
* Adicionado teste de integração do `FacebookAuthController`

# Por que foi feito

Para agilizar o processo de login com Facebook, e tratar o caso de não haver email no perfil do Facebook do usuário.
