### PR TITLE
Visitas

### DIFF
--- a/src/main/java/br/com/academiadev/suicidesquad/controller/VisitasController.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/controller/VisitasController.java
@@ -1,0 +1,40 @@
+package br.com.academiadev.suicidesquad.controller;
+
+
+import br.com.academiadev.suicidesquad.dto.VisitaDTO;
+import br.com.academiadev.suicidesquad.entity.Usuario;
+import br.com.academiadev.suicidesquad.mapper.VisitaMapper;
+import br.com.academiadev.suicidesquad.service.UsuarioService;
+import io.swagger.annotations.ApiOperation;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/visitas")
+public class VisitasController {
+
+    private final UsuarioService usuarioService;
+
+    private final VisitaMapper visitaMapper;
+
+    @Autowired
+    public VisitasController(UsuarioService usuarioService, VisitaMapper visitaMapper) {
+        this.usuarioService = usuarioService;
+        this.visitaMapper = visitaMapper;
+    }
+
+    @GetMapping
+    @ApiOperation(value = "Obtem as visitas do usuário logado")
+    public List<VisitaDTO> getVisitasDoUsuario(@AuthenticationPrincipal Usuario usuarioLogado) {
+        Usuario usuario = usuarioService.findById(usuarioLogado.getId())
+                .orElseThrow(() -> {
+                    return new RuntimeException("Usuário deixou de existir no meio do request");
+                });
+        return visitaMapper.toDtos(usuario.getVisitas());
+    }
+}

--- a/src/main/java/br/com/academiadev/suicidesquad/dto/PetDetailDTO.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/dto/PetDetailDTO.java
@@ -25,4 +25,7 @@ public class PetDetailDTO extends PetDTO {
 
     @ApiModelProperty(value = "Descrição")
     private String descricao;
+
+    @ApiModelProperty(value = "Número de visitas", example = "1")
+    private int n_visitas;
 }

--- a/src/main/java/br/com/academiadev/suicidesquad/dto/VisitaDTO.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/dto/VisitaDTO.java
@@ -1,0 +1,12 @@
+package br.com.academiadev.suicidesquad.dto;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class VisitaDTO {
+    private String usuario_id;
+    private String data;
+    private PetDTO pet;
+}

--- a/src/main/java/br/com/academiadev/suicidesquad/entity/Pet.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/entity/Pet.java
@@ -69,6 +69,14 @@ public class Pet extends AuditableEntity<Long> {
     @Builder.Default
     private List<Registro> registros = new ArrayList<>();
 
+    @OneToMany(
+            mappedBy = "pet",
+            cascade = CascadeType.ALL,
+            orphanRemoval = true
+    )
+    @Builder.Default
+    private List<Visita> visitas = new ArrayList<>();
+
     @Size(min = 2, max = 80)
     private String nome;
 
@@ -99,5 +107,15 @@ public class Pet extends AuditableEntity<Long> {
                 .max(Comparator.comparing(Registro::getData))
                 .map(Registro::getSituacao)
                 .orElse(null);
+    }
+
+    public void addVisita(Usuario usuario) {
+        Visita visita = new Visita(this, usuario);
+        this.visitas.add(visita);
+        usuario.getVisitas().add(visita);
+    }
+
+    public int getNumeroDeVisitas() {
+        return this.visitas.size();
     }
 }

--- a/src/main/java/br/com/academiadev/suicidesquad/entity/Usuario.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/entity/Usuario.java
@@ -66,6 +66,13 @@ public class Usuario extends AuditableEntity<Long> implements UserDetails {
     private List<Pet> pets = new ArrayList<>();
 
     @Builder.Default
+    @OneToMany(
+            mappedBy = "usuario",
+            orphanRemoval = true
+    )
+    private List<Visita> visitas = new ArrayList<>();
+
+    @Builder.Default
     @NotNull
     private boolean emailPublico = true;
 

--- a/src/main/java/br/com/academiadev/suicidesquad/entity/Visita.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/entity/Visita.java
@@ -1,0 +1,41 @@
+package br.com.academiadev.suicidesquad.entity;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Data
+@EqualsAndHashCode(callSuper = true)
+@NoArgsConstructor
+@EntityListeners({AuditingEntityListener.class})
+public class Visita extends BaseEntity<Long> {
+
+    @ManyToOne(
+            fetch = FetchType.LAZY
+    )
+    @JoinColumn(name = "pet_id")
+    private Pet pet;
+
+    @ManyToOne(
+            fetch = FetchType.LAZY
+    )
+    @JoinColumn(name = "usuario_id")
+    private Usuario usuario;
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime dataVisita;
+
+    public Visita(Pet pet, Usuario usuario) {
+        this.pet = pet;
+        this.usuario = usuario;
+    }
+}
+
+

--- a/src/main/java/br/com/academiadev/suicidesquad/mapper/PetMapper.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/mapper/PetMapper.java
@@ -103,6 +103,7 @@ public abstract class PetMapper {
             @Mapping(target = "usuario"),
             @Mapping(target = "registros"),
             @Mapping(target = "email", source = "usuario.emailPublico"),
+            @Mapping(target = "n_visitas", source = "numeroDeVisitas")
 //            @Mapping(target = "telefones", source = "usuario.telefones"),
     })
     public abstract PetDetailDTO toDetailDto(Pet entity);

--- a/src/main/java/br/com/academiadev/suicidesquad/mapper/VisitaMapper.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/mapper/VisitaMapper.java
@@ -1,0 +1,26 @@
+package br.com.academiadev.suicidesquad.mapper;
+
+import br.com.academiadev.suicidesquad.dto.VisitaDTO;
+import br.com.academiadev.suicidesquad.entity.Visita;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Mappings;
+import org.mapstruct.ReportingPolicy;
+
+import java.util.List;
+
+@Mapper(
+        componentModel = "spring",
+        unmappedTargetPolicy = ReportingPolicy.IGNORE,
+        uses = {PetMapper.class}
+)
+public interface VisitaMapper {
+    @Mappings({
+            @Mapping(target = "usuario_id", source = "usuario.id"),
+            @Mapping(target = "pet"),
+            @Mapping(target = "data")
+    })
+    VisitaDTO toDto(Visita entity);
+
+    List<VisitaDTO> toDtos(List<Visita> entities);
+}

--- a/src/main/java/br/com/academiadev/suicidesquad/service/PetService.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/service/PetService.java
@@ -118,4 +118,8 @@ public class PetService {
         final Usuario usuario = (Usuario) authentication.getPrincipal();
         return (pet != null) && (usuario != null) && (usuario.getId() != null) && pet.getUsuario().getId().equals(usuario.getId());
     }
+
+    public void adicionarVisita(Pet pet, Usuario usuario) {
+        pet.addVisita(usuario);
+    }
 }

--- a/src/test/java/br/com/academiadev/suicidesquad/controller/PetControllerTest.java
+++ b/src/test/java/br/com/academiadev/suicidesquad/controller/PetControllerTest.java
@@ -25,9 +25,7 @@ import org.springframework.util.MultiValueMap;
 import java.util.*;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -137,6 +135,18 @@ public class PetControllerTest {
                 .andExpect(jsonPath("$.tipo", equalTo(pet.getTipo().toString())))
                 .andExpect(jsonPath("$.cores[0]", equalTo(pet.getCores().toArray()[0].toString())))
                 .andExpect(jsonPath("$.cores[1]", equalTo(pet.getCores().toArray()[1].toString())));
+    }
+
+    @Test
+    public void obterPet_quandoExisteELogado_entaoRetornaEGravaVisita() throws Exception {
+        Usuario usuario = usuarioService.save(buildUsuario());
+        Pet pet = petService.save(buildPet());
+
+        String token = jwtTokenProvider.getToken(usuario.getUsername(), Collections.emptyList());
+        mvc.perform(get(String.format("/pets/%d", pet.getId()))
+                .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.n_visitas", equalTo(1)));
     }
 
     @Test

--- a/src/test/java/br/com/academiadev/suicidesquad/controller/VisitasControllerTest.java
+++ b/src/test/java/br/com/academiadev/suicidesquad/controller/VisitasControllerTest.java
@@ -1,0 +1,82 @@
+package br.com.academiadev.suicidesquad.controller;
+
+import br.com.academiadev.suicidesquad.entity.Pet;
+import br.com.academiadev.suicidesquad.entity.Usuario;
+import br.com.academiadev.suicidesquad.enums.Categoria;
+import br.com.academiadev.suicidesquad.enums.ComprimentoPelo;
+import br.com.academiadev.suicidesquad.enums.Porte;
+import br.com.academiadev.suicidesquad.enums.Tipo;
+import br.com.academiadev.suicidesquad.security.JwtTokenProvider;
+import br.com.academiadev.suicidesquad.service.PetService;
+import br.com.academiadev.suicidesquad.service.UsuarioService;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+public class VisitasControllerTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Autowired
+    private UsuarioService usuarioService;
+
+    @Autowired
+    private PetService petService;
+
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+
+    private Usuario buildUsuario() {
+        return Usuario.builder()
+                .nome("Fulano")
+                .email("fulano@example.com")
+                .senha("hunter2")
+                .build();
+    }
+
+    @Test
+    public void obterVisitasDoUsuario_quandoExistem_entaoRetorna() throws Exception {
+        final Usuario usuario = usuarioService.save(buildUsuario());
+        final Pet petA = petService.save(Pet.builder()
+                .tipo(Tipo.GATO)
+                .porte(Porte.MEDIO)
+                .comprimentoPelo(ComprimentoPelo.MEDIO)
+                .categoria(Categoria.ACHADO)
+                .build());
+        final Pet petB = petService.save(Pet.builder()
+                .tipo(Tipo.CACHORRO)
+                .porte(Porte.PEQUENO)
+                .comprimentoPelo(ComprimentoPelo.CURTO)
+                .categoria(Categoria.ACHADO)
+                .build());
+        petService.adicionarVisita(petA, usuario);
+        petService.adicionarVisita(petB, usuario);
+
+        String token = jwtTokenProvider.getToken(usuario.getUsername(), Collections.emptyList());
+        mvc.perform(get("/visitas")
+                .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(2)))
+                .andExpect(jsonPath("$[0].pet.tipo", equalTo(petA.getTipo().toString())))
+                .andExpect(jsonPath("$[1].pet.tipo", equalTo(petB.getTipo().toString())));
+    }
+}

--- a/src/test/java/br/com/academiadev/suicidesquad/service/PetServiceTest.java
+++ b/src/test/java/br/com/academiadev/suicidesquad/service/PetServiceTest.java
@@ -1,0 +1,71 @@
+package br.com.academiadev.suicidesquad.service;
+
+import br.com.academiadev.suicidesquad.entity.Pet;
+import br.com.academiadev.suicidesquad.entity.Usuario;
+import br.com.academiadev.suicidesquad.enums.Categoria;
+import br.com.academiadev.suicidesquad.enums.ComprimentoPelo;
+import br.com.academiadev.suicidesquad.enums.Porte;
+import br.com.academiadev.suicidesquad.enums.Tipo;
+import br.com.academiadev.suicidesquad.repository.PetRepository;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import javax.persistence.EntityManager;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = {PetService.class})
+public class PetServiceTest {
+
+    @Autowired
+    PetService petService;
+
+    @MockBean
+    PetRepository petRepository;
+
+    @MockBean
+    EntityManager entityManager;
+
+    private Usuario buildUsuarioA() {
+        return Usuario.builder()
+                .nome("Usuário A")
+                .email("usuario.a@example.com")
+                .senha("hunter2")
+                .build();
+    }
+
+    private Usuario buildUsuarioB() {
+        return Usuario.builder()
+                .nome("Usuário B")
+                .email("usuario.b@example.com")
+                .senha("hunter2")
+                .build();
+    }
+
+    private Pet buildPet() {
+        return Pet.builder()
+                .tipo(Tipo.GATO)
+                .porte(Porte.MEDIO)
+                .comprimentoPelo(ComprimentoPelo.MEDIO)
+                .categoria(Categoria.ACHADO)
+                .build();
+    }
+
+    @Test
+    public void adicionarVisita() {
+        Usuario usuarioA = buildUsuarioA();
+        Usuario usuarioB = buildUsuarioB();
+        Pet pet = buildPet();
+
+        petService.adicionarVisita(pet, usuarioA);
+        assertThat(pet.getNumeroDeVisitas(), equalTo(1));
+        petService.adicionarVisita(pet, usuarioB);
+        assertThat(pet.getNumeroDeVisitas(), equalTo(2));
+    }
+}


### PR DESCRIPTION
Closes #36

# O que foi feito

* Adicionada a entidade `Visita`, que realiza a relação entre `Pet` e `Usuario`, junto de uma data de criação. Os sujeitos da relação também foram modificados para manter referências às suas visitas. O `Pet` é o encarregado de adicionar novas visitas, pelo seu método `addVisita(Usuario usuario)`.
* Adicionado método `adicionarVisita()` ao `PetService`, para que o controlador possa registrar uma visita sem manipular a relação diretamente.
* Adicionada a lógica de registro de visita ao enpoint `GET /pet/{idPet}`, que cria uma nova visita quando há um usuário autenticado no request.
* Adicionado o campo `n_visitas` ao `PetDetailDTO`, junto da `@Mapping` correspondente no `PetMapper`, para retornar a contagem de vistas do pet.
* Definido um `VisitaDTO`, que contém os dados do pet, ID do usuário, e a data da visita.
* Adicionado endpoint `/visitas`, que retorna as visitas do usuário logado.
* Adicionados testes de unidade e de integração para estas funcionalidades.

# Por que foi feito

Para manter um histórico das visitas.