### PR TITLE
elaborado o teste para findPetsInativosNaoNotificadosDoUsuario e feit…

### DIFF
--- a/src/main/java/br/com/academiadev/suicidesquad/service/PetService.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/service/PetService.java
@@ -43,6 +43,9 @@ public class PetService {
     }
 
     public Pet save(Pet pet) {
+        if (pet.getRegistros().isEmpty()){
+            pet.addRegistro(new Registro(pet,Situacao.PROCURANDO));
+        }
         return petRepository.save(pet);
     }
 

--- a/src/test/java/br/com/academiadev/suicidesquad/controller/PetControllerTest.java
+++ b/src/test/java/br/com/academiadev/suicidesquad/controller/PetControllerTest.java
@@ -414,6 +414,6 @@ public class PetControllerTest {
                 .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isBadRequest());
 
-        assertThat(pet.getSituacaoAtual(), nullValue());
+        assertThat(pet.getRegistros().size(), equalTo(1));
     }
 }

--- a/src/test/java/br/com/academiadev/suicidesquad/service/PetServiceInativosTest.java
+++ b/src/test/java/br/com/academiadev/suicidesquad/service/PetServiceInativosTest.java
@@ -1,0 +1,122 @@
+package br.com.academiadev.suicidesquad.service;
+
+import br.com.academiadev.suicidesquad.entity.Pet;
+import br.com.academiadev.suicidesquad.entity.Usuario;
+import br.com.academiadev.suicidesquad.enums.Categoria;
+import br.com.academiadev.suicidesquad.enums.ComprimentoPelo;
+import br.com.academiadev.suicidesquad.enums.Porte;
+import br.com.academiadev.suicidesquad.enums.Tipo;
+import org.apache.tomcat.jni.Local;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+public class PetServiceInativosTest {
+
+    @Autowired
+    MockMvc mvc;
+
+    @Autowired
+    PetService petService;
+
+    @Autowired
+    UsuarioService usuarioService;
+
+    private Usuario buildUsuarioA() {
+        return Usuario.builder()
+                .nome("Usuário A")
+                .email("usuario.a@example.com")
+                .senha("hunter2")
+                .build();
+    }
+
+    private Usuario buildUsuarioB() {
+        return Usuario.builder()
+                .nome("Usuário B")
+                .email("usuario.b@example.com")
+                .senha("hunter2")
+                .build();
+    }
+
+    private Pet buildPet(Usuario usuario) {
+        return Pet.builder()
+                .tipo(Tipo.GATO)
+                .porte(Porte.MEDIO)
+                .comprimentoPelo(ComprimentoPelo.MEDIO)
+                .categoria(Categoria.ACHADO)
+                .usuario(usuario)
+                .build();
+    }
+
+    @Test
+    public void dadoPetInativo_quandoBuscarPetsInativos_entaoRetornaPetInativo() {
+        Usuario usuario = buildUsuarioA();
+        Pet pet = buildPet(usuario);
+
+        Pet pet2 = buildPet(usuario);
+
+        petService.save(pet);
+        petService.save(pet2);
+        usuarioService.save(usuario);
+
+        List<Pet> petsInativos = new ArrayList<>();
+        petsInativos.add(pet);
+
+        pet.getRegistros().get(0).setData(LocalDateTime.now().minusDays(9));
+
+        List<Pet> petsInativosRecebidos = petService.findPetsInativosNaoNotificadosDoUsuario(usuario);
+
+        assertThat(pet.getRegistros().size(), equalTo(1));
+        assertThat(petsInativos, equalTo(petsInativosRecebidos));
+    }
+
+    @Test
+    public void dadoPetsAtivos_quandoBuscarPetsInativos_entaoNenhumPetEncontrado() {
+        Usuario usuario = buildUsuarioA();
+
+        petService.save(buildPet(usuario));
+        petService.save(buildPet(usuario));
+        petService.save(buildPet(usuario));
+        usuarioService.save(usuario);
+
+        List<Pet> petsNaoEncontrados = petService.findPetsInativosNaoNotificadosDoUsuario(usuario);
+
+        assertThat(petsNaoEncontrados, empty());
+    }
+
+    @Test
+    public void dadoPetsInativos_quandoBuscarPertInativos_entaoPetsInativosRetornados() {
+        Usuario usuario = buildUsuarioA();
+
+        List<Pet> petsInativos = new ArrayList<>();
+
+        petsInativos.add(petService.save(buildPet(usuario)));
+        petsInativos.add(petService.save(buildPet(usuario)));
+        petsInativos.add(petService.save(buildPet(usuario)));
+        petsInativos.add(petService.save(buildPet(usuario)));
+
+        petsInativos.forEach(pet -> pet.getRegistros().get(0).setData(LocalDateTime.now().minusWeeks(2)));
+
+        usuarioService.save(usuario);
+
+        List<Pet> petsRetornados = petService.findPetsInativosNaoNotificadosDoUsuario(usuario);
+
+        assertThat(petsInativos, equalTo(petsRetornados));
+    }
+}


### PR DESCRIPTION
## O que foi feito
- Criado teste para o método findPetsInativosNaoNotificadosDoUsuario do PetService
- Alterado o método save em PetService para que ao criar um pet novo e se o mesto estiver sem nenhum registro será adicionado um registro de PROCURANDO
- Alterado o teste adicionarRegistro_quandoInvalido_entaoErro no PetControllerTest para adequar a nova lógica do PetService
## Por quê foi feito?
- O método não possuía testes
- Caso um pet fosse criado e não fosse feita nenhuma modificação o mesmo não seria notificado pois não possuía nenhum registro
- Teste alterado pois agora todos os pets possuem 1 registro que é criado durante o cadastro do pet.