### PR TITLE
Bustar pets do usuário por meio do petRepository, pra não sofrer com lazy loading

### DIFF
--- a/src/main/java/br/com/academiadev/suicidesquad/controller/UsuarioController.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/controller/UsuarioController.java
@@ -4,10 +4,13 @@ import br.com.academiadev.suicidesquad.dto.PetDTO;
 import br.com.academiadev.suicidesquad.dto.UsuarioCreateDTO;
 import br.com.academiadev.suicidesquad.dto.UsuarioDTO;
 import br.com.academiadev.suicidesquad.dto.UsuarioEditDTO;
+import br.com.academiadev.suicidesquad.entity.Pet;
 import br.com.academiadev.suicidesquad.entity.Usuario;
 import br.com.academiadev.suicidesquad.exception.EmailExistenteException;
 import br.com.academiadev.suicidesquad.exception.UsuarioNotFoundException;
+import br.com.academiadev.suicidesquad.mapper.PetMapper;
 import br.com.academiadev.suicidesquad.mapper.UsuarioMapper;
+import br.com.academiadev.suicidesquad.service.PetService;
 import br.com.academiadev.suicidesquad.service.UsuarioService;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
@@ -19,6 +22,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import java.util.List;
 
 @RestController
 public class UsuarioController {
@@ -29,12 +33,18 @@ public class UsuarioController {
 
     private final UsuarioService usuarioService;
 
+    private final PetService petService;
+
     private final UsuarioMapper usuarioMapper;
 
+    private final PetMapper petMapper;
+
     @Autowired
-    public UsuarioController(UsuarioService usuarioService, UsuarioMapper usuarioMapper) {
+    public UsuarioController(UsuarioService usuarioService, UsuarioMapper usuarioMapper, PetService petService, PetMapper petMapper) {
         this.usuarioService = usuarioService;
         this.usuarioMapper = usuarioMapper;
+        this.petService = petService;
+        this.petMapper = petMapper;
     }
 
     @ApiOperation(value = "Retorna o usuário pelo Id")
@@ -85,8 +95,11 @@ public class UsuarioController {
     @ApiResponses({
             @ApiResponse(code=200, message = "List de Pets do Usuário encontrada")
     })
-    @GetMapping("/usuarios/{id}/pets")
-    public Iterable<PetDTO> getPetsByIdUsuario(@PathVariable Long id){
-        return usuarioService.findPetsByUsuario(usuarioService.findById(id).orElseThrow(UsuarioNotFoundException::new));
+    @GetMapping("/usuarios/{idUsuario}/pets")
+    public Iterable<PetDTO> getPetsByIdUsuario(@PathVariable Long idUsuario) {
+        Usuario usuario = usuarioService.findById(idUsuario)
+                .orElseThrow(UsuarioNotFoundException::new);
+        List<Pet> pets = petService.findPetsByUsuario(usuario);
+        return petMapper.toDtos(pets);
     }
 }

--- a/src/main/java/br/com/academiadev/suicidesquad/repository/PetRepository.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/repository/PetRepository.java
@@ -27,4 +27,6 @@ public interface PetRepository extends JpaRepository<Pet, Long>, QuerydslPredica
             "  AND (p.dataNotificacaoDeInatividade < r1.data\n" +
             "       OR p.dataNotificacaoDeInatividade IS NULL)")
     List<Pet> findPetsDoUsuarioInativosNaoNotificadosDesde(Usuario usuario, LocalDateTime dataDeCorte);
+
+    List<Pet> findPetsByUsuario_Id(Long idUsuario);
 }

--- a/src/main/java/br/com/academiadev/suicidesquad/service/PetService.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/service/PetService.java
@@ -42,6 +42,10 @@ public class PetService {
         return petRepository.findById(idPet);
     }
 
+    public List<Pet> findPetsByUsuario(Usuario usuario) {
+        return petRepository.findPetsByUsuario_Id(usuario.getId());
+    }
+
     public Pet save(Pet pet) {
         if (pet.getRegistros().isEmpty()){
             pet.addRegistro(new Registro(pet,Situacao.PROCURANDO));

--- a/src/main/java/br/com/academiadev/suicidesquad/service/UsuarioService.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/service/UsuarioService.java
@@ -1,9 +1,7 @@
 package br.com.academiadev.suicidesquad.service;
 
-import br.com.academiadev.suicidesquad.dto.PetDTO;
 import br.com.academiadev.suicidesquad.entity.Pet;
 import br.com.academiadev.suicidesquad.entity.Usuario;
-import br.com.academiadev.suicidesquad.mapper.PetMapper;
 import br.com.academiadev.suicidesquad.repository.UsuarioRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -14,12 +12,9 @@ import java.util.Optional;
 @Service
 public class UsuarioService {
     private final UsuarioRepository usuarioRepository;
-    private final PetMapper petMapper;
-
     @Autowired
-    public UsuarioService(UsuarioRepository usuarioRepository, PetMapper petMapper) {
+    public UsuarioService(UsuarioRepository usuarioRepository) {
         this.usuarioRepository = usuarioRepository;
-        this.petMapper = petMapper;
     }
 
     public Optional<Usuario> findById(Long id) {
@@ -63,9 +58,5 @@ public class UsuarioService {
 
     public void adicionarFavorito(Usuario usuario, Pet pet){
         usuario.addPetFavorito(pet);
-    }
-
-    public Iterable<PetDTO> findPetsByUsuario(Usuario usuario){
-        return petMapper.toDtos(usuario.getPets());
     }
 }


### PR DESCRIPTION
# O que foi feito

Em vez de usar o método `usuario.getPets()` para obters os pets do endpoint `GET /usuarios/{idUsuario}/pets`, criei um novo método no `PetRepository` para bustar pets pelo ID do usuário.

# Por que foi feito

Como o campo `pets` do `Usuario` tem `fetch=LAZY`, os pets não são carregados, e o endpoint sempre retorna vazio. Os testes estavam passando, pois era utilizado o `.addPet()` diretamente.