### PR TITLE
Alterar login com Facebook para não usar cookies

### DIFF
--- a/src/main/java/br/com/academiadev/suicidesquad/config/SecurityConfig.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/config/SecurityConfig.java
@@ -54,8 +54,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
             .authorizeRequests()
                 .antMatchers(
                     "/auth/facebook/authorization",
-                    "/auth/facebook/cadastrar_e_logar_via_callback",
-                    "/auth/facebook/cadastrar_e_logar_com_email_suplementar",
+                    "/auth/facebook/cadastrar_via_callback",
+                    "/auth/facebook/cadastrar_com_email_suplementar",
                     "/auth/facebook/logar_com_access_token",
                     "/auth/email"
                 ).permitAll()

--- a/src/main/java/br/com/academiadev/suicidesquad/controller/FacebookAuthController.java
+++ b/src/main/java/br/com/academiadev/suicidesquad/controller/FacebookAuthController.java
@@ -6,6 +6,7 @@ import br.com.academiadev.suicidesquad.entity.Usuario;
 import br.com.academiadev.suicidesquad.exception.EmailExistenteException;
 import br.com.academiadev.suicidesquad.exception.InvalidAccessTokenException;
 import br.com.academiadev.suicidesquad.exception.UsuarioExistenteException;
+import br.com.academiadev.suicidesquad.mapper.UsuarioMapper;
 import br.com.academiadev.suicidesquad.security.JwtTokenProvider;
 import br.com.academiadev.suicidesquad.service.FacebookService;
 import br.com.academiadev.suicidesquad.service.UsuarioService;
@@ -43,17 +44,20 @@ public class FacebookAuthController {
 
     private final JwtTokenProvider jwtTokenProvider;
 
+    private final UsuarioMapper usuarioMapper;
+
     private final ObjectMapper objectMapper;
 
     @Value("${app.social.facebook.frontend-redirect-uri:}")
     private String frontendRedirectUri;
 
     @Autowired
-    public FacebookAuthController(FacebookService facebookService, UsuarioService usuarioService, JwtTokenProvider jwtTokenProvider, ObjectMapper objectMapper) {
+    public FacebookAuthController(FacebookService facebookService, UsuarioService usuarioService, JwtTokenProvider jwtTokenProvider, ObjectMapper objectMapper, UsuarioMapper usuarioMapper) {
         this.facebookService = facebookService;
         this.usuarioService = usuarioService;
         this.jwtTokenProvider = jwtTokenProvider;
         this.objectMapper = objectMapper;
+        this.usuarioMapper = usuarioMapper;
     }
 
     @GetMapping("/authorization")
@@ -157,7 +161,7 @@ public class FacebookAuthController {
         String token = jwtTokenProvider.getToken(usuario.getEmail(), Collections.emptyList());
         ObjectNode tokenJson = objectMapper.createObjectNode();
         tokenJson.put("token", token);
-        tokenJson.set("usuario", objectMapper.valueToTree(usuario));
+        tokenJson.set("usuario", objectMapper.valueToTree(usuarioMapper.toDto(usuario)));
         return ResponseEntity.ok(objectMapper.writeValueAsString(tokenJson));
     }
 }

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -5,3 +5,7 @@ app.social.facebook.enabled=false
 
 app.email.provider=sendgrid
 app.email.sendgrid.api-key=${SENDGRID_API_KEY}
+
+
+app.social.facebook.backend-redirect-uri=https://backend-suicide-squad.herokuapp.com/auth/facebook/cadastrar_via_callback
+app.social.facebook.frontend-redirect-uri=https://frontend-suicide-squad-2.herokuapp.com/auth/facebook/cadastrar_e_logar_via_callback

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,7 +2,7 @@ spring.profiles.active=dev
 spring.datasource.url=jdbc:h2:~/test;AUTO_SERVER=TRUE
 
 app.social.facebook.enabled = false
-app.social.facebook.backend-redirect-uri=http://localhost:8080/auth/facebook/cadastrar_e_logar_via_callback
+app.social.facebook.backend-redirect-uri=http://localhost:8080/auth/facebook/cadastrar_via_callback
 app.social.facebook.frontend-redirect-uri=http://localhost:8081/
 
 app.email.sender.domain=404pets.com


### PR DESCRIPTION
# O que foi feito

* Endpoints que antes cadastravam e logavam ao mesmo tempo, agora só cadastram e retornam um access token, que pode ser usado pelo frontend para logar postariormente
* Endpoint de login com access token agora retorna os dados do usuário logado, assim como o de login com email e senha
* Token de sessão é retornado no corpo da resposta, e não em um cookie

# Por que foi feito

Para aumentar o controle do frontend sobre o processo, facilitando as trocas de informação.
